### PR TITLE
Recolor brochure site and refresh copy

### DIFF
--- a/hakkimizda.html
+++ b/hakkimizda.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Enerji Grup Teknik Mühendislik</title>
+    <title>Hakkımızda | Enerji Grup Teknik Mühendislik</title>
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       rel="stylesheet"
@@ -125,8 +125,8 @@
               </svg>
             </button>
             <nav class="hidden items-center gap-8 text-sm font-medium text-white/75 lg:flex">
-              <a class="text-white transition" href="index.html">Anasayfa</a>
-              <a class="transition hover:text-white" href="hakkimizda.html">Hakkımızda</a>
+              <a class="transition hover:text-white" href="index.html">Anasayfa</a>
+              <a class="text-white transition" href="hakkimizda.html">Hakkımızda</a>
               <a class="transition hover:text-white" href="misyon-vizyon.html">Misyon &amp; Vizyon</a>
               <a class="transition hover:text-white" href="uzman-kadro.html">Uzman Kadro</a>
               <a class="transition hover:text-white" href="hizmetler.html">Hizmetler</a>
@@ -138,7 +138,7 @@
         <nav id="mobile-navigation" class="hidden border-t border-white/10 bg-[#0a2035] lg:hidden">
           <div class="flex flex-col px-6 py-4 text-sm text-white/85">
             <a class="rounded-xl px-4 py-3 transition hover:bg-white/10" href="index.html">Anasayfa</a>
-            <a class="rounded-xl px-4 py-3 transition hover:bg-white/10" href="hakkimizda.html">Hakkımızda</a>
+            <a class="rounded-xl px-4 py-3 transition hover:bg-white/10 text-white" href="hakkimizda.html">Hakkımızda</a>
             <a class="rounded-xl px-4 py-3 transition hover:bg-white/10" href="misyon-vizyon.html">Misyon &amp; Vizyon</a>
             <a class="rounded-xl px-4 py-3 transition hover:bg-white/10" href="uzman-kadro.html">Uzman Kadro</a>
             <a class="rounded-xl px-4 py-3 transition hover:bg-white/10" href="hizmetler.html">Hizmetler</a>
@@ -149,107 +149,35 @@
       </header>
 
       <main class="mx-auto flex w-full max-w-[1200px] flex-col gap-12 px-5 py-12 sm:gap-16 sm:px-10 sm:py-16 lg:px-20">
-        <section class="grid items-center gap-8 rounded-[32px] border border-white/10 bg-gradient-to-br from-[#0f2a45]/95 via-[#163d5f]/88 to-[#0a233d]/95 p-6 shadow-[0_25px_60px_rgba(7,20,39,0.55)] sm:gap-10 sm:p-10 lg:grid-cols-[1.2fr_0.8fr] lg:gap-12">
-          <div class="space-y-6">
-            <p class="text-sm uppercase tracking-[0.3em] text-[#b9824b]">Enerji güvenliği</p>
-            <h2 class="text-3xl font-semibold tracking-tight text-white sm:text-4xl">Enerji projelerinizi ileriye taşıyan bağımsız mühendislik ortağı</h2>
-            <p class="text-base leading-relaxed text-white/80">
-              Enerji Grup Teknik Mühendislik, makine mühendisleri ve NDT uzmanlarından oluşan disiplinler arası ekibiyle enerji ve proses tesislerindeki riskleri görünür kılar, verimliliği artıran güvenlik çözümlerini sahaya taşır. Kurucu kadromuzun 15 yılı aşan deneyimi her çalışmada mevzuata uyum ve sürdürülebilirliği birlikte ele almamızı sağlar.
-            </p>
-            <div class="flex flex-col gap-4 sm:flex-row">
-              <a class="inline-flex items-center justify-center rounded-full border border-transparent bg-gradient-to-r from-[#b9824b] via-[#d79d60] to-[#3f85c6] px-8 py-3 text-sm font-semibold text-[#081a2c] shadow-[0_10px_35px_rgba(12,30,43,0.45)] transition hover:scale-105" href="hizmetler.html">
-                Hizmetlerimizi İnceleyin
-              </a>
-              <span class="inline-flex items-center justify-center rounded-full border border-white/20 bg-white/5 px-8 py-3 text-sm font-semibold text-white/75">
-                15+ yıllık saha deneyimi
-              </span>
-            </div>
-          </div>
-          <div class="space-y-6">
-            <div class="rounded-[28px] border border-dashed border-white/20 bg-white/10 p-6 text-center text-sm text-white/70 sm:p-8">
-              <p class="font-medium text-white">Logo için ayrılan alan</p>
-              <p class="mt-2 leading-relaxed text-white/70">
-                Firmanızın güncel logosunu bu alana ekleyebilirsiniz. Görsel oranı 1:1 olacak şekilde (ör. 600×600px PNG) eklenmesi önerilir.
+        <section class="overflow-hidden rounded-[36px] border border-white/10 bg-gradient-to-br from-[#0f2a45]/95 via-[#163d5f]/90 to-[#0a233d]/95 shadow-[0_25px_60px_rgba(5,12,16,0.55)]">
+          <div class="grid items-center gap-8 p-6 sm:gap-10 sm:p-10 lg:grid-cols-[1.1fr_0.9fr]">
+            <div class="space-y-6">
+              <p class="text-xs uppercase tracking-[0.35em] text-[#b9824b]">Kurumsal yaklaşım</p>
+              <h2 class="text-3xl font-semibold tracking-tight text-white sm:text-4xl">Enerji Grup Teknik Mühendislik kimdir?</h2>
+              <p class="text-base leading-relaxed text-white/80">
+                2023 yılında Mersin'de kurulan Enerji Grup Teknik Mühendislik, makine mühendisliği ve tahribatsız muayene disiplinlerinde uzmanlaşmış kadrosunu tek bir çatı altında birleştirir. Enerji üretiminden proses tesislerine kadar uzanan yelpazede bağımsız mühendislik, denetim ve danışmanlık hizmetleri sunarak tesislerin güvenli, verimli ve mevzuata uyumlu biçimde işletilmesini destekliyoruz.
+              </p>
+              <p class="text-base leading-relaxed text-white/80">
+                Uzun yıllara yayılan saha deneyimimizi risk analizi, bakım planlaması ve belgelendirme süreçleriyle harmanlayarak müşterilerimizin sürdürülebilirlik hedeflerine katkı sağlıyoruz. Her projede şeffaf raporlama ve ölçülebilir sonuçlar üretmek bizim için temel prensip.
               </p>
             </div>
-            <div class="space-y-3 rounded-[28px] border border-white/10 bg-[#14324d]/70 p-6">
-              <p class="text-sm font-semibold uppercase tracking-[0.2em] text-[#b9824b]">Kuruluş</p>
-              <p class="text-sm leading-relaxed text-white/80">
-                2023'te Mersin'de kurulan firmamız, endüstriyel tesislerin bakım, kontrol ve belgelendirme ihtiyacına çözüm sunmak için tecrübeli mühendisleri ortak bir çatı altında buluşturdu.
-              </p>
+            <div class="relative h-full min-h-[220px] overflow-hidden rounded-[28px] border border-white/10 sm:min-h-[280px]">
+              <img class="h-full w-full object-cover opacity-80" src="https://images.unsplash.com/photo-1520607162513-77705c0f0d4a?auto=format&amp;fit=crop&amp;w=1200&amp;q=80" alt="Kurumsal ofis binası" loading="lazy" />
+              <div class="absolute inset-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent"></div>
             </div>
           </div>
         </section>
 
-        <section class="fade-in space-y-10" aria-labelledby="kesfet-baslik">
-          <div class="space-y-4 text-center">
-            <p class="text-xs uppercase tracking-[0.35em] text-[#b9824b]">Ana menü</p>
-            <h2 id="kesfet-baslik" class="text-3xl font-semibold tracking-tight text-white">Enerji Grup Teknik'i keşfedin</h2>
-            <p class="mx-auto max-w-3xl text-sm leading-relaxed text-white/75">
-              Kurumsal anlatımızı, uzmanlık öne çıkanlarını ve teknik içerikleri tematik sayfalarda topladık. Fotoğraflı kartlara dokunarak sizi ilgilendiren konuya birkaç saniyede ulaşabilirsiniz.
-            </p>
-          </div>
-          <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
-            <a class="group relative overflow-hidden rounded-[28px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] transition hover:-translate-y-1 hover:border-[#b9824b]/60" href="hakkimizda.html">
-              <img class="h-40 w-full object-cover opacity-80 transition duration-500 group-hover:scale-105 sm:h-48" src="https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&amp;fit=crop&amp;w=900&amp;q=80" alt="Kurumsal binayı temsil eden gece ışıkları" loading="lazy" />
-              <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent"></div>
-              <div class="relative space-y-3 p-6">
-                <p class="text-xs uppercase tracking-[0.3em] text-[#b9824b]">Kurumsal</p>
-                <h3 class="text-xl font-semibold text-white">Hakkımızda</h3>
-                <p class="text-sm text-white/80">Kurumsal yapılanmamızı ve bağımsız çalışma kültürümüzü inceleyin.</p>
-                <span class="inline-flex items-center gap-2 text-sm font-semibold text-[#d79d60]">Sayfayı aç <svg class="size-4" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9 6L15 12L9 18" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" /></svg></span>
-              </div>
-            </a>
-            <a class="group relative overflow-hidden rounded-[28px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] transition hover:-translate-y-1 hover:border-[#b9824b]/60" href="misyon-vizyon.html">
-              <img class="h-40 w-full object-cover opacity-80 transition duration-500 group-hover:scale-105 sm:h-48" src="https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&amp;fit=crop&amp;w=900&amp;q=80" alt="Soyut ışıklarla çizilmiş vizyon konsepti" loading="lazy" />
-              <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent"></div>
-              <div class="relative space-y-3 p-6">
-                <p class="text-xs uppercase tracking-[0.3em] text-[#b9824b]">Strateji</p>
-                <h3 class="text-xl font-semibold text-white">Misyon &amp; Vizyon</h3>
-                <p class="text-sm text-white/80">Yol haritamızı şekillendiren hedefleri ve değer zincirimizi keşfedin.</p>
-                <span class="inline-flex items-center gap-2 text-sm font-semibold text-[#d79d60]">Sayfayı aç <svg class="size-4" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9 6L15 12L9 18" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" /></svg></span>
-              </div>
-            </a>
-            <a class="group relative overflow-hidden rounded-[28px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] transition hover:-translate-y-1 hover:border-[#b9824b]/60" href="uzman-kadro.html">
-              <img class="h-40 w-full object-cover opacity-80 transition duration-500 group-hover:scale-105 sm:h-48" src="https://images.unsplash.com/photo-1581091870627-3fdc0086580d?auto=format&amp;fit=crop&amp;w=900&amp;q=80" alt="Teknik ekip çalışmasını temsil eden görsel" loading="lazy" />
-              <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent"></div>
-              <div class="relative space-y-3 p-6">
-                <p class="text-xs uppercase tracking-[0.3em] text-[#b9824b]">Ekip</p>
-                <h3 class="text-xl font-semibold text-white">Uzman Kadro</h3>
-                <p class="text-sm text-white/80">Saha deneyimi yüksek ekibimizin yetkinliklerini yakından görün.</p>
-                <span class="inline-flex items-center gap-2 text-sm font-semibold text-[#d79d60]">Sayfayı aç <svg class="size-4" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9 6L15 12L9 18" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" /></svg></span>
-              </div>
-            </a>
-            <a class="group relative overflow-hidden rounded-[28px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] transition hover:-translate-y-1 hover:border-[#b9824b]/60" href="hizmetler.html">
-              <img class="h-40 w-full object-cover opacity-80 transition duration-500 group-hover:scale-105 sm:h-48" src="https://images.unsplash.com/photo-1503387762-592deb58ef4e?auto=format&amp;fit=crop&amp;w=900&amp;q=80" alt="Endüstriyel tesislerde mühendislik hizmetlerini simgeleyen görsel" loading="lazy" />
-              <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent"></div>
-              <div class="relative space-y-3 p-6">
-                <p class="text-xs uppercase tracking-[0.3em] text-[#b9824b]">Çözümler</p>
-                <h3 class="text-xl font-semibold text-white">Hizmetlerimiz</h3>
-                <p class="text-sm text-white/80">Kontrol, danışmanlık ve tasarım başlıklarının tamamını keşfedin.</p>
-                <span class="inline-flex items-center gap-2 text-sm font-semibold text-[#d79d60]">Sayfayı aç <svg class="size-4" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9 6L15 12L9 18" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" /></svg></span>
-              </div>
-            </a>
-            <a class="group relative overflow-hidden rounded-[28px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] transition hover:-translate-y-1 hover:border-[#b9824b]/60" href="ndt.html">
-              <img class="h-40 w-full object-cover opacity-80 transition duration-500 group-hover:scale-105 sm:h-48" src="https://images.unsplash.com/photo-1517433456452-f9633a875f6f?auto=format&amp;fit=crop&amp;w=900&amp;q=80" alt="Tahribatsız muayene ekipmanı" loading="lazy" />
-              <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent"></div>
-              <div class="relative space-y-3 p-6">
-                <p class="text-xs uppercase tracking-[0.3em] text-[#b9824b]">Denetim</p>
-                <h3 class="text-xl font-semibold text-white">Tahribatsız Muayene</h3>
-                <p class="text-sm text-white/80">Uluslararası standartlara dayalı NDT yöntemlerimizi inceleyin.</p>
-                <span class="inline-flex items-center gap-2 text-sm font-semibold text-[#d79d60]">Sayfayı aç <svg class="size-4" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9 6L15 12L9 18" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" /></svg></span>
-              </div>
-            </a>
-            <a class="group relative overflow-hidden rounded-[28px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] transition hover:-translate-y-1 hover:border-[#b9824b]/60" href="periyodik-kontroller.html">
-              <img class="h-40 w-full object-cover opacity-80 transition duration-500 group-hover:scale-105 sm:h-48" src="https://images.unsplash.com/photo-1518770660439-4636190af475?auto=format&amp;fit=crop&amp;w=900&amp;q=80" alt="Periyodik kontrol ve bakım süreçlerini temsil eden görsel" loading="lazy" />
-              <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent"></div>
-              <div class="relative space-y-3 p-6">
-                <p class="text-xs uppercase tracking-[0.3em] text-[#b9824b]">Süreklilik</p>
-                <h3 class="text-xl font-semibold text-white">Periyodik Kontroller</h3>
-                <p class="text-sm text-white/80">Zorunlu periyodik kontrol başlıklarının tamamına göz atın.</p>
-                <span class="inline-flex items-center gap-2 text-sm font-semibold text-[#d79d60]">Sayfayı aç <svg class="size-4" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9 6L15 12L9 18" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" /></svg></span>
-              </div>
-            </a>
+        <section class="fade-in space-y-8">
+          <div class="grid gap-6 lg:grid-cols-2">
+            <article class="rounded-[28px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] p-6 leading-relaxed text-white/80 sm:p-8">
+              <h3 class="text-xl font-semibold text-white">Bağımsız çalışma kültürü</h3>
+              <p class="mt-4">Tarafsız karar alma, detaylı raporlama ve erişilebilir iletişim hatları; müşterilerimize sunduğumuz her hizmet paketinin temel taşlarıdır.</p>
+            </article>
+            <article class="rounded-[28px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] p-6 leading-relaxed text-white/80 sm:p-8">
+              <h3 class="text-xl font-semibold text-white">Çalıştığımız sektörler</h3>
+              <p class="mt-4">Enerji, üretim, gıda ve kimya tesislerinde periyodik kontrol, proje doğrulama ve belgelendirme süreçlerini uçtan uca yönetiyoruz.</p>
+            </article>
           </div>
         </section>
       </main>

--- a/hizmetler.html
+++ b/hizmetler.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Enerji Grup Teknik Mühendislik</title>
+    <title>Hizmetler | Enerji Grup Teknik Mühendislik</title>
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       rel="stylesheet"
@@ -125,11 +125,11 @@
               </svg>
             </button>
             <nav class="hidden items-center gap-8 text-sm font-medium text-white/75 lg:flex">
-              <a class="text-white transition" href="index.html">Anasayfa</a>
+              <a class="transition hover:text-white" href="index.html">Anasayfa</a>
               <a class="transition hover:text-white" href="hakkimizda.html">Hakkımızda</a>
               <a class="transition hover:text-white" href="misyon-vizyon.html">Misyon &amp; Vizyon</a>
               <a class="transition hover:text-white" href="uzman-kadro.html">Uzman Kadro</a>
-              <a class="transition hover:text-white" href="hizmetler.html">Hizmetler</a>
+              <a class="text-white transition" href="hizmetler.html">Hizmetler</a>
               <a class="transition hover:text-white" href="ndt.html">Tahribatsız Muayene</a>
               <a class="transition hover:text-white" href="periyodik-kontroller.html">Periyodik Kontroller</a>
             </nav>
@@ -141,7 +141,7 @@
             <a class="rounded-xl px-4 py-3 transition hover:bg-white/10" href="hakkimizda.html">Hakkımızda</a>
             <a class="rounded-xl px-4 py-3 transition hover:bg-white/10" href="misyon-vizyon.html">Misyon &amp; Vizyon</a>
             <a class="rounded-xl px-4 py-3 transition hover:bg-white/10" href="uzman-kadro.html">Uzman Kadro</a>
-            <a class="rounded-xl px-4 py-3 transition hover:bg-white/10" href="hizmetler.html">Hizmetler</a>
+            <a class="rounded-xl px-4 py-3 transition hover:bg-white/10 text-white" href="hizmetler.html">Hizmetler</a>
             <a class="rounded-xl px-4 py-3 transition hover:bg-white/10" href="ndt.html">Tahribatsız Muayene</a>
             <a class="rounded-xl px-4 py-3 transition hover:bg-white/10" href="periyodik-kontroller.html">Periyodik Kontroller</a>
           </div>
@@ -149,107 +149,86 @@
       </header>
 
       <main class="mx-auto flex w-full max-w-[1200px] flex-col gap-12 px-5 py-12 sm:gap-16 sm:px-10 sm:py-16 lg:px-20">
-        <section class="grid items-center gap-8 rounded-[32px] border border-white/10 bg-gradient-to-br from-[#0f2a45]/95 via-[#163d5f]/88 to-[#0a233d]/95 p-6 shadow-[0_25px_60px_rgba(7,20,39,0.55)] sm:gap-10 sm:p-10 lg:grid-cols-[1.2fr_0.8fr] lg:gap-12">
-          <div class="space-y-6">
-            <p class="text-sm uppercase tracking-[0.3em] text-[#b9824b]">Enerji güvenliği</p>
-            <h2 class="text-3xl font-semibold tracking-tight text-white sm:text-4xl">Enerji projelerinizi ileriye taşıyan bağımsız mühendislik ortağı</h2>
-            <p class="text-base leading-relaxed text-white/80">
-              Enerji Grup Teknik Mühendislik, makine mühendisleri ve NDT uzmanlarından oluşan disiplinler arası ekibiyle enerji ve proses tesislerindeki riskleri görünür kılar, verimliliği artıran güvenlik çözümlerini sahaya taşır. Kurucu kadromuzun 15 yılı aşan deneyimi her çalışmada mevzuata uyum ve sürdürülebilirliği birlikte ele almamızı sağlar.
-            </p>
-            <div class="flex flex-col gap-4 sm:flex-row">
-              <a class="inline-flex items-center justify-center rounded-full border border-transparent bg-gradient-to-r from-[#b9824b] via-[#d79d60] to-[#3f85c6] px-8 py-3 text-sm font-semibold text-[#081a2c] shadow-[0_10px_35px_rgba(12,30,43,0.45)] transition hover:scale-105" href="hizmetler.html">
-                Hizmetlerimizi İnceleyin
-              </a>
-              <span class="inline-flex items-center justify-center rounded-full border border-white/20 bg-white/5 px-8 py-3 text-sm font-semibold text-white/75">
-                15+ yıllık saha deneyimi
-              </span>
-            </div>
-          </div>
-          <div class="space-y-6">
-            <div class="rounded-[28px] border border-dashed border-white/20 bg-white/10 p-6 text-center text-sm text-white/70 sm:p-8">
-              <p class="font-medium text-white">Logo için ayrılan alan</p>
-              <p class="mt-2 leading-relaxed text-white/70">
-                Firmanızın güncel logosunu bu alana ekleyebilirsiniz. Görsel oranı 1:1 olacak şekilde (ör. 600×600px PNG) eklenmesi önerilir.
+        <section class="overflow-hidden rounded-[36px] border border-white/10 bg-gradient-to-br from-[#0f2a45]/95 via-[#163d5f]/90 to-[#0a233d]/95 shadow-[0_25px_60px_rgba(5,12,16,0.55)]">
+          <div class="grid items-center gap-8 p-6 sm:gap-10 sm:p-10 lg:grid-cols-[1.05fr_0.95fr]">
+            <div class="space-y-6">
+              <p class="text-xs uppercase tracking-[0.35em] text-[#b9824b]">Uzmanlık alanlarımız</p>
+              <h2 class="text-3xl font-semibold tracking-tight text-white sm:text-4xl">Mühendislik çözümlerimiz</h2>
+              <p class="text-base leading-relaxed text-white/80">
+                Periyodik kontrolleri, tahribatsız muayeneleri ve danışmanlık süreçlerini tek merkezden yöneterek tesislerinizin mevzuata uyumunu ve operasyon güvenliğini güçlendiriyoruz.
               </p>
             </div>
-            <div class="space-y-3 rounded-[28px] border border-white/10 bg-[#14324d]/70 p-6">
-              <p class="text-sm font-semibold uppercase tracking-[0.2em] text-[#b9824b]">Kuruluş</p>
-              <p class="text-sm leading-relaxed text-white/80">
-                2023'te Mersin'de kurulan firmamız, endüstriyel tesislerin bakım, kontrol ve belgelendirme ihtiyacına çözüm sunmak için tecrübeli mühendisleri ortak bir çatı altında buluşturdu.
-              </p>
+            <div class="relative h-full min-h-[220px] overflow-hidden rounded-[28px] border border-white/10 sm:min-h-[280px]">
+              <img class="h-full w-full object-cover opacity-80" src="https://images.unsplash.com/photo-1503387762-592deb58ef4e?auto=format&amp;fit=crop&amp;w=1200&amp;q=80" alt="Endüstriyel tesis" loading="lazy" />
+              <div class="absolute inset-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent"></div>
             </div>
           </div>
         </section>
 
-        <section class="fade-in space-y-10" aria-labelledby="kesfet-baslik">
-          <div class="space-y-4 text-center">
-            <p class="text-xs uppercase tracking-[0.35em] text-[#b9824b]">Ana menü</p>
-            <h2 id="kesfet-baslik" class="text-3xl font-semibold tracking-tight text-white">Enerji Grup Teknik'i keşfedin</h2>
-            <p class="mx-auto max-w-3xl text-sm leading-relaxed text-white/75">
-              Kurumsal anlatımızı, uzmanlık öne çıkanlarını ve teknik içerikleri tematik sayfalarda topladık. Fotoğraflı kartlara dokunarak sizi ilgilendiren konuya birkaç saniyede ulaşabilirsiniz.
+        <section class="fade-in space-y-10">
+          <div class="grid gap-6 lg:grid-cols-2">
+            <article class="rounded-[28px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] p-6 text-base leading-relaxed text-white/80 sm:p-8">
+              <h3 class="text-lg font-semibold text-white">Mekanik ve güvenlik kontrolleri</h3>
+              <ul class="mt-4 space-y-3 text-sm text-white/75">
+                <li>• Tahribatsız Muayene (VT, MT, PT, UT)</li>
+                <li>• Basınçlı Kaplar ve Kaldırma Araçları için Periyodik Kontrol</li>
+                <li>• Yangın tesisatı ve ekipmanlarının periyodik kontrolleri</li>
+                <li>• Pompa performans ölçümleri ve verim analizleri</li>
+              </ul>
+            </article>
+            <article class="rounded-[28px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] p-6 text-base leading-relaxed text-white/80 sm:p-8">
+              <h3 class="text-lg font-semibold text-white">Mühendislik ve danışmanlık</h3>
+              <ul class="mt-4 space-y-3 text-sm text-white/75">
+                <li>• 3. Taraf Gözetim Hizmetleri</li>
+                <li>• Elektrik tesisatı, parafudor ve topraklama ölçümleri</li>
+                <li>• Endüstriyel rafların bilgisayar destekli statik analizi ve kapasite tayini</li>
+                <li>• Bilirkişilik, danışmanlık ve müşavirlik hizmetleri</li>
+                <li>• Sıhhi tesisat, ısıtma, havalandırma ve yangın tesisatı projelendirme</li>
+                <li>• Enerji kimlik belgesi hizmetleri</li>
+                <li>• AİTM (Araçların İmal, Tadil ve Montajı Hakkında Yönetmelik) projelendirme</li>
+              </ul>
+            </article>
+          </div>
+        </section>
+
+        <section class="fade-in space-y-8">
+          <div class="space-y-6 rounded-[32px] border border-[#b9824b]/30 bg-gradient-to-br from-[#171f2c]/95 via-[#1d2b3a]/90 to-[#101722]/95 p-6 text-white/80 sm:p-10">
+            <p class="text-xs uppercase tracking-[0.32em] text-[#d79d60]">Kaynaklı imalat çözümleri</p>
+            <h3 class="text-2xl font-semibold tracking-tight text-white">Kaynak süreçlerine yönelik uzman desteğimiz</h3>
+            <p>
+              Basınçlı kaplar, köprüler, boru hatları ve ağır sanayi tesisleri gibi yapılarda kaynak operasyonları maliyet ve ürün kalitesi üzerinde belirleyicidir.
+              Bu üretimleri gerçekleştiren işletmelerin ve ürünlerin uluslararası standart ve direktiflere göre doğrulanması ve belgelendirilmesi zorunludur.
+            </p>
+            <p>
+              Enerji Grup Teknik Mühendislik, kaynaklı imalat projelerinde onay, belgelendirme ve gözetim gereksinimlerini uluslararası çözüm ortaklarıyla birlikte yönetir.
+              Uzman mühendis ekibimiz saha çalışmalarından raporlamaya kadar her aşamada kesintisiz destek sağlar.
             </p>
           </div>
-          <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
-            <a class="group relative overflow-hidden rounded-[28px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] transition hover:-translate-y-1 hover:border-[#b9824b]/60" href="hakkimizda.html">
-              <img class="h-40 w-full object-cover opacity-80 transition duration-500 group-hover:scale-105 sm:h-48" src="https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&amp;fit=crop&amp;w=900&amp;q=80" alt="Kurumsal binayı temsil eden gece ışıkları" loading="lazy" />
-              <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent"></div>
-              <div class="relative space-y-3 p-6">
-                <p class="text-xs uppercase tracking-[0.3em] text-[#b9824b]">Kurumsal</p>
-                <h3 class="text-xl font-semibold text-white">Hakkımızda</h3>
-                <p class="text-sm text-white/80">Kurumsal yapılanmamızı ve bağımsız çalışma kültürümüzü inceleyin.</p>
-                <span class="inline-flex items-center gap-2 text-sm font-semibold text-[#d79d60]">Sayfayı aç <svg class="size-4" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9 6L15 12L9 18" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" /></svg></span>
-              </div>
-            </a>
-            <a class="group relative overflow-hidden rounded-[28px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] transition hover:-translate-y-1 hover:border-[#b9824b]/60" href="misyon-vizyon.html">
-              <img class="h-40 w-full object-cover opacity-80 transition duration-500 group-hover:scale-105 sm:h-48" src="https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&amp;fit=crop&amp;w=900&amp;q=80" alt="Soyut ışıklarla çizilmiş vizyon konsepti" loading="lazy" />
-              <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent"></div>
-              <div class="relative space-y-3 p-6">
-                <p class="text-xs uppercase tracking-[0.3em] text-[#b9824b]">Strateji</p>
-                <h3 class="text-xl font-semibold text-white">Misyon &amp; Vizyon</h3>
-                <p class="text-sm text-white/80">Yol haritamızı şekillendiren hedefleri ve değer zincirimizi keşfedin.</p>
-                <span class="inline-flex items-center gap-2 text-sm font-semibold text-[#d79d60]">Sayfayı aç <svg class="size-4" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9 6L15 12L9 18" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" /></svg></span>
-              </div>
-            </a>
-            <a class="group relative overflow-hidden rounded-[28px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] transition hover:-translate-y-1 hover:border-[#b9824b]/60" href="uzman-kadro.html">
-              <img class="h-40 w-full object-cover opacity-80 transition duration-500 group-hover:scale-105 sm:h-48" src="https://images.unsplash.com/photo-1581091870627-3fdc0086580d?auto=format&amp;fit=crop&amp;w=900&amp;q=80" alt="Teknik ekip çalışmasını temsil eden görsel" loading="lazy" />
-              <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent"></div>
-              <div class="relative space-y-3 p-6">
-                <p class="text-xs uppercase tracking-[0.3em] text-[#b9824b]">Ekip</p>
-                <h3 class="text-xl font-semibold text-white">Uzman Kadro</h3>
-                <p class="text-sm text-white/80">Saha deneyimi yüksek ekibimizin yetkinliklerini yakından görün.</p>
-                <span class="inline-flex items-center gap-2 text-sm font-semibold text-[#d79d60]">Sayfayı aç <svg class="size-4" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9 6L15 12L9 18" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" /></svg></span>
-              </div>
-            </a>
-            <a class="group relative overflow-hidden rounded-[28px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] transition hover:-translate-y-1 hover:border-[#b9824b]/60" href="hizmetler.html">
-              <img class="h-40 w-full object-cover opacity-80 transition duration-500 group-hover:scale-105 sm:h-48" src="https://images.unsplash.com/photo-1503387762-592deb58ef4e?auto=format&amp;fit=crop&amp;w=900&amp;q=80" alt="Endüstriyel tesislerde mühendislik hizmetlerini simgeleyen görsel" loading="lazy" />
-              <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent"></div>
-              <div class="relative space-y-3 p-6">
-                <p class="text-xs uppercase tracking-[0.3em] text-[#b9824b]">Çözümler</p>
-                <h3 class="text-xl font-semibold text-white">Hizmetlerimiz</h3>
-                <p class="text-sm text-white/80">Kontrol, danışmanlık ve tasarım başlıklarının tamamını keşfedin.</p>
-                <span class="inline-flex items-center gap-2 text-sm font-semibold text-[#d79d60]">Sayfayı aç <svg class="size-4" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9 6L15 12L9 18" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" /></svg></span>
-              </div>
-            </a>
-            <a class="group relative overflow-hidden rounded-[28px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] transition hover:-translate-y-1 hover:border-[#b9824b]/60" href="ndt.html">
-              <img class="h-40 w-full object-cover opacity-80 transition duration-500 group-hover:scale-105 sm:h-48" src="https://images.unsplash.com/photo-1517433456452-f9633a875f6f?auto=format&amp;fit=crop&amp;w=900&amp;q=80" alt="Tahribatsız muayene ekipmanı" loading="lazy" />
-              <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent"></div>
-              <div class="relative space-y-3 p-6">
-                <p class="text-xs uppercase tracking-[0.3em] text-[#b9824b]">Denetim</p>
-                <h3 class="text-xl font-semibold text-white">Tahribatsız Muayene</h3>
-                <p class="text-sm text-white/80">Uluslararası standartlara dayalı NDT yöntemlerimizi inceleyin.</p>
-                <span class="inline-flex items-center gap-2 text-sm font-semibold text-[#d79d60]">Sayfayı aç <svg class="size-4" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9 6L15 12L9 18" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" /></svg></span>
-              </div>
-            </a>
-            <a class="group relative overflow-hidden rounded-[28px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] transition hover:-translate-y-1 hover:border-[#b9824b]/60" href="periyodik-kontroller.html">
-              <img class="h-40 w-full object-cover opacity-80 transition duration-500 group-hover:scale-105 sm:h-48" src="https://images.unsplash.com/photo-1518770660439-4636190af475?auto=format&amp;fit=crop&amp;w=900&amp;q=80" alt="Periyodik kontrol ve bakım süreçlerini temsil eden görsel" loading="lazy" />
-              <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent"></div>
-              <div class="relative space-y-3 p-6">
-                <p class="text-xs uppercase tracking-[0.3em] text-[#b9824b]">Süreklilik</p>
-                <h3 class="text-xl font-semibold text-white">Periyodik Kontroller</h3>
-                <p class="text-sm text-white/80">Zorunlu periyodik kontrol başlıklarının tamamına göz atın.</p>
-                <span class="inline-flex items-center gap-2 text-sm font-semibold text-[#d79d60]">Sayfayı aç <svg class="size-4" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9 6L15 12L9 18" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" /></svg></span>
-              </div>
-            </a>
+          <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+            <div class="rounded-[24px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] p-6 text-white/80">
+              <h4 class="text-lg font-semibold text-white">Mekanik kaynak gözetimi</h4>
+              <p class="mt-3 text-sm leading-relaxed text-white/75">Kaynaklı imalat aşamalarında süreçleri standartlara göre denetliyor, üretim kayıtlarının düzenli tutulmasını sağlıyoruz.</p>
+            </div>
+            <div class="rounded-[24px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] p-6 text-white/80">
+              <h4 class="text-lg font-semibold text-white">Kaynak metodu onayları</h4>
+              <p class="mt-3 text-sm leading-relaxed text-white/75">Kaynak yöntem onaylarını hazırlıyor, prosedürlerinizi belgelerle destekleyerek denetimlerden sorunsuz geçmenizi sağlıyoruz.</p>
+            </div>
+            <div class="rounded-[24px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] p-6 text-white/80">
+              <h4 class="text-lg font-semibold text-white">Kaynakçı sertifikasyonu</h4>
+              <p class="mt-3 text-sm leading-relaxed text-white/75">Kaynak personelinizin (WPQ) yeterliliklerini değerlendiriyor, ulusal ve uluslararası standartlara uygun sertifikasyon süreçlerini yönetiyoruz.</p>
+            </div>
+            <div class="rounded-[24px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] p-6 text-white/80">
+              <h4 class="text-lg font-semibold text-white">WPS hazırlığı</h4>
+              <p class="mt-3 text-sm leading-relaxed text-white/75">Kaynak prosedür şartnamelerini (WPS) oluşturuyor, WPQR testlerini organize ederek dokümantasyonunuzu eksiksiz tamamlıyoruz.</p>
+            </div>
+            <div class="rounded-[24px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] p-6 text-white/80">
+              <h4 class="text-lg font-semibold text-white">Kaynak testleri ve muayeneleri</h4>
+              <p class="mt-3 text-sm leading-relaxed text-white/75">Tahribatsız ve tahribatlı testleri planlayarak kaynaklı birleşimlerin dayanımını doğruluyoruz.</p>
+            </div>
+            <div class="rounded-[24px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] p-6 text-white/80">
+              <h4 class="text-lg font-semibold text-white">ISO 3834 &amp; ISO 9001 entegrasyonu</h4>
+              <p class="mt-3 text-sm leading-relaxed text-white/75">Kaynaklı imalat süreçlerinizde ISO 3834 ve ISO 9001 gerekliliklerini kurarak sürdürülebilir kalite yönetim altyapısı oluşturuyoruz.</p>
+            </div>
           </div>
         </section>
       </main>

--- a/misyon-vizyon.html
+++ b/misyon-vizyon.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Enerji Grup Teknik Mühendislik</title>
+    <title>Misyon &amp; Vizyon | Enerji Grup Teknik Mühendislik</title>
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       rel="stylesheet"
@@ -125,9 +125,9 @@
               </svg>
             </button>
             <nav class="hidden items-center gap-8 text-sm font-medium text-white/75 lg:flex">
-              <a class="text-white transition" href="index.html">Anasayfa</a>
+              <a class="transition hover:text-white" href="index.html">Anasayfa</a>
               <a class="transition hover:text-white" href="hakkimizda.html">Hakkımızda</a>
-              <a class="transition hover:text-white" href="misyon-vizyon.html">Misyon &amp; Vizyon</a>
+              <a class="text-white transition" href="misyon-vizyon.html">Misyon &amp; Vizyon</a>
               <a class="transition hover:text-white" href="uzman-kadro.html">Uzman Kadro</a>
               <a class="transition hover:text-white" href="hizmetler.html">Hizmetler</a>
               <a class="transition hover:text-white" href="ndt.html">Tahribatsız Muayene</a>
@@ -139,7 +139,7 @@
           <div class="flex flex-col px-6 py-4 text-sm text-white/85">
             <a class="rounded-xl px-4 py-3 transition hover:bg-white/10" href="index.html">Anasayfa</a>
             <a class="rounded-xl px-4 py-3 transition hover:bg-white/10" href="hakkimizda.html">Hakkımızda</a>
-            <a class="rounded-xl px-4 py-3 transition hover:bg-white/10" href="misyon-vizyon.html">Misyon &amp; Vizyon</a>
+            <a class="rounded-xl px-4 py-3 transition hover:bg-white/10 text-white" href="misyon-vizyon.html">Misyon &amp; Vizyon</a>
             <a class="rounded-xl px-4 py-3 transition hover:bg-white/10" href="uzman-kadro.html">Uzman Kadro</a>
             <a class="rounded-xl px-4 py-3 transition hover:bg-white/10" href="hizmetler.html">Hizmetler</a>
             <a class="rounded-xl px-4 py-3 transition hover:bg-white/10" href="ndt.html">Tahribatsız Muayene</a>
@@ -149,107 +149,34 @@
       </header>
 
       <main class="mx-auto flex w-full max-w-[1200px] flex-col gap-12 px-5 py-12 sm:gap-16 sm:px-10 sm:py-16 lg:px-20">
-        <section class="grid items-center gap-8 rounded-[32px] border border-white/10 bg-gradient-to-br from-[#0f2a45]/95 via-[#163d5f]/88 to-[#0a233d]/95 p-6 shadow-[0_25px_60px_rgba(7,20,39,0.55)] sm:gap-10 sm:p-10 lg:grid-cols-[1.2fr_0.8fr] lg:gap-12">
-          <div class="space-y-6">
-            <p class="text-sm uppercase tracking-[0.3em] text-[#b9824b]">Enerji güvenliği</p>
-            <h2 class="text-3xl font-semibold tracking-tight text-white sm:text-4xl">Enerji projelerinizi ileriye taşıyan bağımsız mühendislik ortağı</h2>
-            <p class="text-base leading-relaxed text-white/80">
-              Enerji Grup Teknik Mühendislik, makine mühendisleri ve NDT uzmanlarından oluşan disiplinler arası ekibiyle enerji ve proses tesislerindeki riskleri görünür kılar, verimliliği artıran güvenlik çözümlerini sahaya taşır. Kurucu kadromuzun 15 yılı aşan deneyimi her çalışmada mevzuata uyum ve sürdürülebilirliği birlikte ele almamızı sağlar.
-            </p>
-            <div class="flex flex-col gap-4 sm:flex-row">
-              <a class="inline-flex items-center justify-center rounded-full border border-transparent bg-gradient-to-r from-[#b9824b] via-[#d79d60] to-[#3f85c6] px-8 py-3 text-sm font-semibold text-[#081a2c] shadow-[0_10px_35px_rgba(12,30,43,0.45)] transition hover:scale-105" href="hizmetler.html">
-                Hizmetlerimizi İnceleyin
-              </a>
-              <span class="inline-flex items-center justify-center rounded-full border border-white/20 bg-white/5 px-8 py-3 text-sm font-semibold text-white/75">
-                15+ yıllık saha deneyimi
-              </span>
-            </div>
-          </div>
-          <div class="space-y-6">
-            <div class="rounded-[28px] border border-dashed border-white/20 bg-white/10 p-6 text-center text-sm text-white/70 sm:p-8">
-              <p class="font-medium text-white">Logo için ayrılan alan</p>
-              <p class="mt-2 leading-relaxed text-white/70">
-                Firmanızın güncel logosunu bu alana ekleyebilirsiniz. Görsel oranı 1:1 olacak şekilde (ör. 600×600px PNG) eklenmesi önerilir.
-              </p>
-            </div>
-            <div class="space-y-3 rounded-[28px] border border-white/10 bg-[#14324d]/70 p-6">
-              <p class="text-sm font-semibold uppercase tracking-[0.2em] text-[#b9824b]">Kuruluş</p>
-              <p class="text-sm leading-relaxed text-white/80">
-                2023'te Mersin'de kurulan firmamız, endüstriyel tesislerin bakım, kontrol ve belgelendirme ihtiyacına çözüm sunmak için tecrübeli mühendisleri ortak bir çatı altında buluşturdu.
+        <section class="overflow-hidden rounded-[36px] border border-white/10 bg-gradient-to-br from-[#0f2a45]/95 via-[#163d5f]/90 to-[#0a233d]/95 shadow-[0_25px_60px_rgba(5,12,16,0.55)]">
+          <div class="relative h-[260px] w-full overflow-hidden sm:h-[320px]">
+            <img class="h-full w-full object-cover opacity-70" src="https://images.unsplash.com/photo-1517638851339-4aa32003c11a?auto=format&amp;fit=crop&amp;w=1400&amp;q=80" alt="Soyut vizyon konsepti" loading="lazy" />
+            <div class="absolute inset-0 bg-gradient-to-br from-black/80 via-black/30 to-transparent"></div>
+            <div class="absolute inset-0 flex flex-col justify-end gap-4 px-6 pb-10 sm:px-10 sm:pb-12">
+              <p class="text-xs uppercase tracking-[0.35em] text-[#b9824b]">Stratejik odağımız</p>
+              <h2 class="text-3xl font-semibold tracking-tight text-white sm:text-4xl">Misyonumuz ve vizyonumuz</h2>
+              <p class="max-w-2xl text-sm leading-relaxed text-white/80">
+                Sanayi işletmelerine sunduğumuz tüm mühendislik süreçlerini ulusal ve uluslararası standartlara bağlı kalarak yürütüyor, bağımsızlığımızı ve müşteri memnuniyetini aynı anda koruyoruz.
               </p>
             </div>
           </div>
         </section>
 
-        <section class="fade-in space-y-10" aria-labelledby="kesfet-baslik">
-          <div class="space-y-4 text-center">
-            <p class="text-xs uppercase tracking-[0.35em] text-[#b9824b]">Ana menü</p>
-            <h2 id="kesfet-baslik" class="text-3xl font-semibold tracking-tight text-white">Enerji Grup Teknik'i keşfedin</h2>
-            <p class="mx-auto max-w-3xl text-sm leading-relaxed text-white/75">
-              Kurumsal anlatımızı, uzmanlık öne çıkanlarını ve teknik içerikleri tematik sayfalarda topladık. Fotoğraflı kartlara dokunarak sizi ilgilendiren konuya birkaç saniyede ulaşabilirsiniz.
-            </p>
-          </div>
-          <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
-            <a class="group relative overflow-hidden rounded-[28px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] transition hover:-translate-y-1 hover:border-[#b9824b]/60" href="hakkimizda.html">
-              <img class="h-40 w-full object-cover opacity-80 transition duration-500 group-hover:scale-105 sm:h-48" src="https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&amp;fit=crop&amp;w=900&amp;q=80" alt="Kurumsal binayı temsil eden gece ışıkları" loading="lazy" />
-              <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent"></div>
-              <div class="relative space-y-3 p-6">
-                <p class="text-xs uppercase tracking-[0.3em] text-[#b9824b]">Kurumsal</p>
-                <h3 class="text-xl font-semibold text-white">Hakkımızda</h3>
-                <p class="text-sm text-white/80">Kurumsal yapılanmamızı ve bağımsız çalışma kültürümüzü inceleyin.</p>
-                <span class="inline-flex items-center gap-2 text-sm font-semibold text-[#d79d60]">Sayfayı aç <svg class="size-4" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9 6L15 12L9 18" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" /></svg></span>
-              </div>
-            </a>
-            <a class="group relative overflow-hidden rounded-[28px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] transition hover:-translate-y-1 hover:border-[#b9824b]/60" href="misyon-vizyon.html">
-              <img class="h-40 w-full object-cover opacity-80 transition duration-500 group-hover:scale-105 sm:h-48" src="https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&amp;fit=crop&amp;w=900&amp;q=80" alt="Soyut ışıklarla çizilmiş vizyon konsepti" loading="lazy" />
-              <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent"></div>
-              <div class="relative space-y-3 p-6">
-                <p class="text-xs uppercase tracking-[0.3em] text-[#b9824b]">Strateji</p>
-                <h3 class="text-xl font-semibold text-white">Misyon &amp; Vizyon</h3>
-                <p class="text-sm text-white/80">Yol haritamızı şekillendiren hedefleri ve değer zincirimizi keşfedin.</p>
-                <span class="inline-flex items-center gap-2 text-sm font-semibold text-[#d79d60]">Sayfayı aç <svg class="size-4" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9 6L15 12L9 18" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" /></svg></span>
-              </div>
-            </a>
-            <a class="group relative overflow-hidden rounded-[28px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] transition hover:-translate-y-1 hover:border-[#b9824b]/60" href="uzman-kadro.html">
-              <img class="h-40 w-full object-cover opacity-80 transition duration-500 group-hover:scale-105 sm:h-48" src="https://images.unsplash.com/photo-1581091870627-3fdc0086580d?auto=format&amp;fit=crop&amp;w=900&amp;q=80" alt="Teknik ekip çalışmasını temsil eden görsel" loading="lazy" />
-              <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent"></div>
-              <div class="relative space-y-3 p-6">
-                <p class="text-xs uppercase tracking-[0.3em] text-[#b9824b]">Ekip</p>
-                <h3 class="text-xl font-semibold text-white">Uzman Kadro</h3>
-                <p class="text-sm text-white/80">Saha deneyimi yüksek ekibimizin yetkinliklerini yakından görün.</p>
-                <span class="inline-flex items-center gap-2 text-sm font-semibold text-[#d79d60]">Sayfayı aç <svg class="size-4" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9 6L15 12L9 18" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" /></svg></span>
-              </div>
-            </a>
-            <a class="group relative overflow-hidden rounded-[28px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] transition hover:-translate-y-1 hover:border-[#b9824b]/60" href="hizmetler.html">
-              <img class="h-40 w-full object-cover opacity-80 transition duration-500 group-hover:scale-105 sm:h-48" src="https://images.unsplash.com/photo-1503387762-592deb58ef4e?auto=format&amp;fit=crop&amp;w=900&amp;q=80" alt="Endüstriyel tesislerde mühendislik hizmetlerini simgeleyen görsel" loading="lazy" />
-              <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent"></div>
-              <div class="relative space-y-3 p-6">
-                <p class="text-xs uppercase tracking-[0.3em] text-[#b9824b]">Çözümler</p>
-                <h3 class="text-xl font-semibold text-white">Hizmetlerimiz</h3>
-                <p class="text-sm text-white/80">Kontrol, danışmanlık ve tasarım başlıklarının tamamını keşfedin.</p>
-                <span class="inline-flex items-center gap-2 text-sm font-semibold text-[#d79d60]">Sayfayı aç <svg class="size-4" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9 6L15 12L9 18" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" /></svg></span>
-              </div>
-            </a>
-            <a class="group relative overflow-hidden rounded-[28px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] transition hover:-translate-y-1 hover:border-[#b9824b]/60" href="ndt.html">
-              <img class="h-40 w-full object-cover opacity-80 transition duration-500 group-hover:scale-105 sm:h-48" src="https://images.unsplash.com/photo-1517433456452-f9633a875f6f?auto=format&amp;fit=crop&amp;w=900&amp;q=80" alt="Tahribatsız muayene ekipmanı" loading="lazy" />
-              <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent"></div>
-              <div class="relative space-y-3 p-6">
-                <p class="text-xs uppercase tracking-[0.3em] text-[#b9824b]">Denetim</p>
-                <h3 class="text-xl font-semibold text-white">Tahribatsız Muayene</h3>
-                <p class="text-sm text-white/80">Uluslararası standartlara dayalı NDT yöntemlerimizi inceleyin.</p>
-                <span class="inline-flex items-center gap-2 text-sm font-semibold text-[#d79d60]">Sayfayı aç <svg class="size-4" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9 6L15 12L9 18" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" /></svg></span>
-              </div>
-            </a>
-            <a class="group relative overflow-hidden rounded-[28px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] transition hover:-translate-y-1 hover:border-[#b9824b]/60" href="periyodik-kontroller.html">
-              <img class="h-40 w-full object-cover opacity-80 transition duration-500 group-hover:scale-105 sm:h-48" src="https://images.unsplash.com/photo-1518770660439-4636190af475?auto=format&amp;fit=crop&amp;w=900&amp;q=80" alt="Periyodik kontrol ve bakım süreçlerini temsil eden görsel" loading="lazy" />
-              <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent"></div>
-              <div class="relative space-y-3 p-6">
-                <p class="text-xs uppercase tracking-[0.3em] text-[#b9824b]">Süreklilik</p>
-                <h3 class="text-xl font-semibold text-white">Periyodik Kontroller</h3>
-                <p class="text-sm text-white/80">Zorunlu periyodik kontrol başlıklarının tamamına göz atın.</p>
-                <span class="inline-flex items-center gap-2 text-sm font-semibold text-[#d79d60]">Sayfayı aç <svg class="size-4" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9 6L15 12L9 18" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" /></svg></span>
-              </div>
-            </a>
+        <section class="fade-in space-y-10">
+          <div class="grid gap-6 lg:grid-cols-2">
+            <article class="rounded-[28px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] p-6 leading-relaxed text-white/80 sm:p-8">
+              <h3 class="text-xl font-semibold text-white">Misyonumuz</h3>
+              <p class="mt-4">
+                Sanayi işletmelerinin ve tesislerinin yasal mevzuat kapsamında ihtiyaç duyduğu mühendislik uygulamalarında güncel, kapsamlı ve güvenilir çözümleri zamanında sunuyoruz. İş sürekliliğini güçlendirirken işletmelerin sorumluluklarını güvenle yerine getirmesine katkı sağlamak temel hedefimiz.
+              </p>
+            </article>
+            <article class="rounded-[28px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] p-6 leading-relaxed text-white/80 sm:p-8">
+              <h3 class="text-xl font-semibold text-white">Vizyonumuz</h3>
+              <p class="mt-4">
+                Türkiye'deki sanayi kuruluşları için bağımsızlık, tarafsızlık ve dürüstlük ilkelerini koruyarak standartlara uygunluk sağlayan; tesisleri güvenle kullanılır hale getiren ve işletmelere süreklilik kazandıran çözüm ortağı olarak konumlanmak vizyonumuzdur.
+              </p>
+            </article>
           </div>
         </section>
       </main>
@@ -264,7 +191,7 @@
                 <span class="inline-flex w-fit items-center gap-2 rounded-full border border-white/15 bg-white/10 px-4 py-1.5 text-xs font-semibold uppercase tracking-[0.32em] text-[#c9d6df]">Enerji Grup Teknik</span>
                 <h2 class="text-3xl font-semibold tracking-tight sm:text-4xl">Geleceğin enerjisini birlikte inşa edelim</h2>
                 <p class="max-w-xl text-sm leading-relaxed text-white/75">
-                  Yetkin mühendis kadromuzla enerji altyapısındaki kritik riskleri analiz ediyor, işletmelerin güvenliğini güçlendiren çağdaş çözümler geliştiriyoruz.
+                  Yetkin mühendis kadromuzla enerji altyapısındaki riskleri analiz ediyor, işletmelerin güvenliğini güçlendiren çağdaş çözümler geliştiriyoruz.
                 </p>
               </div>
               <a class="inline-flex items-center justify-center gap-2 rounded-full border border-[#b9824b]/40 bg-gradient-to-r from-[#b9824b] via-[#d79d60] to-[#3f85c6] px-8 py-3 text-sm font-semibold text-[#081a2c] shadow-[0_15px_45px_rgba(10,25,36,0.55)] transition hover:scale-105" href="mailto:info@enerjigrupteknik.com">

--- a/ndt.html
+++ b/ndt.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Enerji Grup Teknik Mühendislik</title>
+    <title>Tahribatsız Muayene | Enerji Grup Teknik Mühendislik</title>
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       rel="stylesheet"
@@ -125,12 +125,12 @@
               </svg>
             </button>
             <nav class="hidden items-center gap-8 text-sm font-medium text-white/75 lg:flex">
-              <a class="text-white transition" href="index.html">Anasayfa</a>
+              <a class="transition hover:text-white" href="index.html">Anasayfa</a>
               <a class="transition hover:text-white" href="hakkimizda.html">Hakkımızda</a>
               <a class="transition hover:text-white" href="misyon-vizyon.html">Misyon &amp; Vizyon</a>
               <a class="transition hover:text-white" href="uzman-kadro.html">Uzman Kadro</a>
               <a class="transition hover:text-white" href="hizmetler.html">Hizmetler</a>
-              <a class="transition hover:text-white" href="ndt.html">Tahribatsız Muayene</a>
+              <a class="text-white transition" href="ndt.html">Tahribatsız Muayene</a>
               <a class="transition hover:text-white" href="periyodik-kontroller.html">Periyodik Kontroller</a>
             </nav>
           </div>
@@ -142,114 +142,79 @@
             <a class="rounded-xl px-4 py-3 transition hover:bg-white/10" href="misyon-vizyon.html">Misyon &amp; Vizyon</a>
             <a class="rounded-xl px-4 py-3 transition hover:bg-white/10" href="uzman-kadro.html">Uzman Kadro</a>
             <a class="rounded-xl px-4 py-3 transition hover:bg-white/10" href="hizmetler.html">Hizmetler</a>
-            <a class="rounded-xl px-4 py-3 transition hover:bg-white/10" href="ndt.html">Tahribatsız Muayene</a>
+            <a class="rounded-xl px-4 py-3 transition hover:bg-white/10 text-white" href="ndt.html">Tahribatsız Muayene</a>
             <a class="rounded-xl px-4 py-3 transition hover:bg-white/10" href="periyodik-kontroller.html">Periyodik Kontroller</a>
           </div>
         </nav>
       </header>
 
       <main class="mx-auto flex w-full max-w-[1200px] flex-col gap-12 px-5 py-12 sm:gap-16 sm:px-10 sm:py-16 lg:px-20">
-        <section class="grid items-center gap-8 rounded-[32px] border border-white/10 bg-gradient-to-br from-[#0f2a45]/95 via-[#163d5f]/88 to-[#0a233d]/95 p-6 shadow-[0_25px_60px_rgba(7,20,39,0.55)] sm:gap-10 sm:p-10 lg:grid-cols-[1.2fr_0.8fr] lg:gap-12">
-          <div class="space-y-6">
-            <p class="text-sm uppercase tracking-[0.3em] text-[#b9824b]">Enerji güvenliği</p>
-            <h2 class="text-3xl font-semibold tracking-tight text-white sm:text-4xl">Enerji projelerinizi ileriye taşıyan bağımsız mühendislik ortağı</h2>
-            <p class="text-base leading-relaxed text-white/80">
-              Enerji Grup Teknik Mühendislik, makine mühendisleri ve NDT uzmanlarından oluşan disiplinler arası ekibiyle enerji ve proses tesislerindeki riskleri görünür kılar, verimliliği artıran güvenlik çözümlerini sahaya taşır. Kurucu kadromuzun 15 yılı aşan deneyimi her çalışmada mevzuata uyum ve sürdürülebilirliği birlikte ele almamızı sağlar.
-            </p>
-            <div class="flex flex-col gap-4 sm:flex-row">
-              <a class="inline-flex items-center justify-center rounded-full border border-transparent bg-gradient-to-r from-[#b9824b] via-[#d79d60] to-[#3f85c6] px-8 py-3 text-sm font-semibold text-[#081a2c] shadow-[0_10px_35px_rgba(12,30,43,0.45)] transition hover:scale-105" href="hizmetler.html">
-                Hizmetlerimizi İnceleyin
-              </a>
-              <span class="inline-flex items-center justify-center rounded-full border border-white/20 bg-white/5 px-8 py-3 text-sm font-semibold text-white/75">
-                15+ yıllık saha deneyimi
-              </span>
-            </div>
-          </div>
-          <div class="space-y-6">
-            <div class="rounded-[28px] border border-dashed border-white/20 bg-white/10 p-6 text-center text-sm text-white/70 sm:p-8">
-              <p class="font-medium text-white">Logo için ayrılan alan</p>
-              <p class="mt-2 leading-relaxed text-white/70">
-                Firmanızın güncel logosunu bu alana ekleyebilirsiniz. Görsel oranı 1:1 olacak şekilde (ör. 600×600px PNG) eklenmesi önerilir.
+        <section class="overflow-hidden rounded-[36px] border border-white/10 bg-gradient-to-br from-[#0f2a45]/95 via-[#163d5f]/90 to-[#0a233d]/95 shadow-[0_25px_60px_rgba(5,12,16,0.55)]">
+          <div class="grid items-center gap-8 p-6 sm:gap-10 sm:p-10 lg:grid-cols-[1.05fr_0.95fr]">
+            <div class="space-y-6">
+              <p class="text-xs uppercase tracking-[0.35em] text-[#b9824b]">Denetim yaklaşımımız</p>
+              <h2 class="text-3xl font-semibold tracking-tight text-white sm:text-4xl">Tahribatsız Muayene hizmetlerimiz</h2>
+              <p class="text-base leading-relaxed text-white/80">
+                Non Destructive Testing (NDT) hizmetlerimiz, ekipman ve parçaların üretim ya da kullanım aşamasında yüzeyde ve yüzey altında oluşabilecek kusurları tespit etmeye odaklanan yöntemleri kapsar.
+              </p>
+              <p class="text-base leading-relaxed text-white/80">
+                Kritik ekipmanlara düzenli uygulanan muayeneler, olası hasarları erkenden görünür kılarak üretim sürekliliğini ve iş güvenliğini korur.
               </p>
             </div>
-            <div class="space-y-3 rounded-[28px] border border-white/10 bg-[#14324d]/70 p-6">
-              <p class="text-sm font-semibold uppercase tracking-[0.2em] text-[#b9824b]">Kuruluş</p>
-              <p class="text-sm leading-relaxed text-white/80">
-                2023'te Mersin'de kurulan firmamız, endüstriyel tesislerin bakım, kontrol ve belgelendirme ihtiyacına çözüm sunmak için tecrübeli mühendisleri ortak bir çatı altında buluşturdu.
-              </p>
+            <div class="relative h-full min-h-[220px] overflow-hidden rounded-[28px] border border-white/10 sm:min-h-[320px]">
+              <img class="h-full w-full object-cover opacity-80" src="https://images.unsplash.com/photo-1517433456452-f9633a875f6f?auto=format&amp;fit=crop&amp;w=1200&amp;q=80" alt="Tahribatsız muayene ekipmanı" loading="lazy" />
+              <div class="absolute inset-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent"></div>
             </div>
           </div>
         </section>
 
-        <section class="fade-in space-y-10" aria-labelledby="kesfet-baslik">
-          <div class="space-y-4 text-center">
-            <p class="text-xs uppercase tracking-[0.35em] text-[#b9824b]">Ana menü</p>
-            <h2 id="kesfet-baslik" class="text-3xl font-semibold tracking-tight text-white">Enerji Grup Teknik'i keşfedin</h2>
-            <p class="mx-auto max-w-3xl text-sm leading-relaxed text-white/75">
-              Kurumsal anlatımızı, uzmanlık öne çıkanlarını ve teknik içerikleri tematik sayfalarda topladık. Fotoğraflı kartlara dokunarak sizi ilgilendiren konuya birkaç saniyede ulaşabilirsiniz.
+        <section class="fade-in space-y-8">
+          <article class="rounded-[28px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] p-6 leading-relaxed text-white/80 sm:p-8">
+            <p>
+              Tahribatsız muayene uygulamalarımız, makine ve teçhizatların bağlı olduğu imalat standartları ile sertifikasyon gereklilikleri çerçevesinde planlanır. Tüm çalışmalar TS EN ISO 9712 sertifikalı uzmanlarımız tarafından yürütülür ve raporlarımız ilgili standartları eksiksiz kapsar.
+            </p>
+            <p class="mt-4">
+              Portföyümüzde Gözle Muayene (VT), Sıvı Penetrant Muayene (PT), Manyetik Parçacık Muayene (MT), Ultrasonik Muayene (UT) ve gerektiğinde Radyografik Muayene (RT) yer alır. Yöntem tercihinde malzeme özellikleri, kullanım amacı ve ekipmanın çalışma koşulları dikkate alınır.
+            </p>
+          </article>
+        </section>
+
+        <section class="fade-in space-y-10">
+          <div class="space-y-6 rounded-[28px] border border-[#3f85c6]/30 bg-gradient-to-br from-[#0f2a45]/90 via-[#172c3d]/90 to-[#0d243d]/90 p-6 text-white/80 sm:p-8">
+            <h3 class="text-2xl font-semibold tracking-tight text-white">NDT uygulamalarında yaklaşımımız</h3>
+            <p>
+              TS EN ISO 9712 sertifikalı makine mühendisi ekibimizle, İş Ekipmanlarının Kullanımında Sağlık ve Güvenlik Şartları Yönetmeliği ve ilgili standartlara bağlı kalarak malzeme, makine ve ekipmanların tahribatsız muayenelerini işletmenizin koşullarına uygun şekilde planlıyoruz.
+            </p>
+            <p>
+              Deneyimli uzmanlarımız periyodik kontrollerde gözle görülmeyen riskleri ortaya çıkarır, ekipman güvenliğini güçlendirir ve mevzuata uyum sürecinizi belgeler.
             </p>
           </div>
-          <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
-            <a class="group relative overflow-hidden rounded-[28px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] transition hover:-translate-y-1 hover:border-[#b9824b]/60" href="hakkimizda.html">
-              <img class="h-40 w-full object-cover opacity-80 transition duration-500 group-hover:scale-105 sm:h-48" src="https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&amp;fit=crop&amp;w=900&amp;q=80" alt="Kurumsal binayı temsil eden gece ışıkları" loading="lazy" />
-              <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent"></div>
-              <div class="relative space-y-3 p-6">
-                <p class="text-xs uppercase tracking-[0.3em] text-[#b9824b]">Kurumsal</p>
-                <h3 class="text-xl font-semibold text-white">Hakkımızda</h3>
-                <p class="text-sm text-white/80">Kurumsal yapılanmamızı ve bağımsız çalışma kültürümüzü inceleyin.</p>
-                <span class="inline-flex items-center gap-2 text-sm font-semibold text-[#d79d60]">Sayfayı aç <svg class="size-4" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9 6L15 12L9 18" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" /></svg></span>
-              </div>
-            </a>
-            <a class="group relative overflow-hidden rounded-[28px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] transition hover:-translate-y-1 hover:border-[#b9824b]/60" href="misyon-vizyon.html">
-              <img class="h-40 w-full object-cover opacity-80 transition duration-500 group-hover:scale-105 sm:h-48" src="https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&amp;fit=crop&amp;w=900&amp;q=80" alt="Soyut ışıklarla çizilmiş vizyon konsepti" loading="lazy" />
-              <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent"></div>
-              <div class="relative space-y-3 p-6">
-                <p class="text-xs uppercase tracking-[0.3em] text-[#b9824b]">Strateji</p>
-                <h3 class="text-xl font-semibold text-white">Misyon &amp; Vizyon</h3>
-                <p class="text-sm text-white/80">Yol haritamızı şekillendiren hedefleri ve değer zincirimizi keşfedin.</p>
-                <span class="inline-flex items-center gap-2 text-sm font-semibold text-[#d79d60]">Sayfayı aç <svg class="size-4" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9 6L15 12L9 18" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" /></svg></span>
-              </div>
-            </a>
-            <a class="group relative overflow-hidden rounded-[28px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] transition hover:-translate-y-1 hover:border-[#b9824b]/60" href="uzman-kadro.html">
-              <img class="h-40 w-full object-cover opacity-80 transition duration-500 group-hover:scale-105 sm:h-48" src="https://images.unsplash.com/photo-1581091870627-3fdc0086580d?auto=format&amp;fit=crop&amp;w=900&amp;q=80" alt="Teknik ekip çalışmasını temsil eden görsel" loading="lazy" />
-              <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent"></div>
-              <div class="relative space-y-3 p-6">
-                <p class="text-xs uppercase tracking-[0.3em] text-[#b9824b]">Ekip</p>
-                <h3 class="text-xl font-semibold text-white">Uzman Kadro</h3>
-                <p class="text-sm text-white/80">Saha deneyimi yüksek ekibimizin yetkinliklerini yakından görün.</p>
-                <span class="inline-flex items-center gap-2 text-sm font-semibold text-[#d79d60]">Sayfayı aç <svg class="size-4" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9 6L15 12L9 18" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" /></svg></span>
-              </div>
-            </a>
-            <a class="group relative overflow-hidden rounded-[28px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] transition hover:-translate-y-1 hover:border-[#b9824b]/60" href="hizmetler.html">
-              <img class="h-40 w-full object-cover opacity-80 transition duration-500 group-hover:scale-105 sm:h-48" src="https://images.unsplash.com/photo-1503387762-592deb58ef4e?auto=format&amp;fit=crop&amp;w=900&amp;q=80" alt="Endüstriyel tesislerde mühendislik hizmetlerini simgeleyen görsel" loading="lazy" />
-              <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent"></div>
-              <div class="relative space-y-3 p-6">
-                <p class="text-xs uppercase tracking-[0.3em] text-[#b9824b]">Çözümler</p>
-                <h3 class="text-xl font-semibold text-white">Hizmetlerimiz</h3>
-                <p class="text-sm text-white/80">Kontrol, danışmanlık ve tasarım başlıklarının tamamını keşfedin.</p>
-                <span class="inline-flex items-center gap-2 text-sm font-semibold text-[#d79d60]">Sayfayı aç <svg class="size-4" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9 6L15 12L9 18" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" /></svg></span>
-              </div>
-            </a>
-            <a class="group relative overflow-hidden rounded-[28px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] transition hover:-translate-y-1 hover:border-[#b9824b]/60" href="ndt.html">
-              <img class="h-40 w-full object-cover opacity-80 transition duration-500 group-hover:scale-105 sm:h-48" src="https://images.unsplash.com/photo-1517433456452-f9633a875f6f?auto=format&amp;fit=crop&amp;w=900&amp;q=80" alt="Tahribatsız muayene ekipmanı" loading="lazy" />
-              <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent"></div>
-              <div class="relative space-y-3 p-6">
-                <p class="text-xs uppercase tracking-[0.3em] text-[#b9824b]">Denetim</p>
-                <h3 class="text-xl font-semibold text-white">Tahribatsız Muayene</h3>
-                <p class="text-sm text-white/80">Uluslararası standartlara dayalı NDT yöntemlerimizi inceleyin.</p>
-                <span class="inline-flex items-center gap-2 text-sm font-semibold text-[#d79d60]">Sayfayı aç <svg class="size-4" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9 6L15 12L9 18" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" /></svg></span>
-              </div>
-            </a>
-            <a class="group relative overflow-hidden rounded-[28px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] transition hover:-translate-y-1 hover:border-[#b9824b]/60" href="periyodik-kontroller.html">
-              <img class="h-40 w-full object-cover opacity-80 transition duration-500 group-hover:scale-105 sm:h-48" src="https://images.unsplash.com/photo-1518770660439-4636190af475?auto=format&amp;fit=crop&amp;w=900&amp;q=80" alt="Periyodik kontrol ve bakım süreçlerini temsil eden görsel" loading="lazy" />
-              <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent"></div>
-              <div class="relative space-y-3 p-6">
-                <p class="text-xs uppercase tracking-[0.3em] text-[#b9824b]">Süreklilik</p>
-                <h3 class="text-xl font-semibold text-white">Periyodik Kontroller</h3>
-                <p class="text-sm text-white/80">Zorunlu periyodik kontrol başlıklarının tamamına göz atın.</p>
-                <span class="inline-flex items-center gap-2 text-sm font-semibold text-[#d79d60]">Sayfayı aç <svg class="size-4" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9 6L15 12L9 18" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" /></svg></span>
-              </div>
-            </a>
+
+          <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
+            <div class="group rounded-[24px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] p-6 transition hover:border-[#b9824b]/60">
+              <h4 class="text-lg font-semibold text-white">Penetrant Muayenesi (PT)</h4>
+              <p class="mt-3 text-sm leading-relaxed text-white/75">
+                Yüzeye açık çatlak ve süreksizliklerin tespitine yönelik renkli veya floresan penetrantlarla ayrıntılı inceleme sunar.
+              </p>
+            </div>
+            <div class="group rounded-[24px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] p-6 transition hover:border-[#b9824b]/60">
+              <h4 class="text-lg font-semibold text-white">Manyetik Parçacık Muayenesi (MT)</h4>
+              <p class="mt-3 text-sm leading-relaxed text-white/75">
+                Manyetize edilmiş ferromanyetik malzemelerde yüzey ve yüzey altı hatalarını yüksek hassasiyetle ortaya çıkarır.
+              </p>
+            </div>
+            <div class="group rounded-[24px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] p-6 transition hover:border-[#b9824b]/60">
+              <h4 class="text-lg font-semibold text-white">Ultrasonik Muayene (UT)</h4>
+              <p class="mt-3 text-sm leading-relaxed text-white/75">
+                Ses dalgalarıyla malzeme içindeki kusurları milimetre hassasiyetinde saptayarak kritik bileşenlerin güvenliğini sağlar.
+              </p>
+            </div>
+            <div class="group rounded-[24px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] p-6 transition hover:border-[#b9824b]/60">
+              <h4 class="text-lg font-semibold text-white">Gözle Muayene (VT)</h4>
+              <p class="mt-3 text-sm leading-relaxed text-white/75">
+                Deneyimli uzmanlarımız, kaynaklı birleşimler ve yüzeyler üzerinde standartlara uygun görsel incelemeler gerçekleştirir.
+              </p>
+            </div>
           </div>
         </section>
       </main>

--- a/periyodik-kontroller.html
+++ b/periyodik-kontroller.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Enerji Grup Teknik Mühendislik</title>
+    <title>Periyodik Kontroller | Enerji Grup Teknik Mühendislik</title>
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       rel="stylesheet"
@@ -125,13 +125,13 @@
               </svg>
             </button>
             <nav class="hidden items-center gap-8 text-sm font-medium text-white/75 lg:flex">
-              <a class="text-white transition" href="index.html">Anasayfa</a>
+              <a class="transition hover:text-white" href="index.html">Anasayfa</a>
               <a class="transition hover:text-white" href="hakkimizda.html">Hakkımızda</a>
               <a class="transition hover:text-white" href="misyon-vizyon.html">Misyon &amp; Vizyon</a>
               <a class="transition hover:text-white" href="uzman-kadro.html">Uzman Kadro</a>
               <a class="transition hover:text-white" href="hizmetler.html">Hizmetler</a>
               <a class="transition hover:text-white" href="ndt.html">Tahribatsız Muayene</a>
-              <a class="transition hover:text-white" href="periyodik-kontroller.html">Periyodik Kontroller</a>
+              <a class="text-white transition" href="periyodik-kontroller.html">Periyodik Kontroller</a>
             </nav>
           </div>
         </div>
@@ -143,114 +143,121 @@
             <a class="rounded-xl px-4 py-3 transition hover:bg-white/10" href="uzman-kadro.html">Uzman Kadro</a>
             <a class="rounded-xl px-4 py-3 transition hover:bg-white/10" href="hizmetler.html">Hizmetler</a>
             <a class="rounded-xl px-4 py-3 transition hover:bg-white/10" href="ndt.html">Tahribatsız Muayene</a>
-            <a class="rounded-xl px-4 py-3 transition hover:bg-white/10" href="periyodik-kontroller.html">Periyodik Kontroller</a>
+            <a class="rounded-xl px-4 py-3 transition hover:bg-white/10 text-white" href="periyodik-kontroller.html">Periyodik Kontroller</a>
           </div>
         </nav>
       </header>
 
       <main class="mx-auto flex w-full max-w-[1200px] flex-col gap-12 px-5 py-12 sm:gap-16 sm:px-10 sm:py-16 lg:px-20">
-        <section class="grid items-center gap-8 rounded-[32px] border border-white/10 bg-gradient-to-br from-[#0f2a45]/95 via-[#163d5f]/88 to-[#0a233d]/95 p-6 shadow-[0_25px_60px_rgba(7,20,39,0.55)] sm:gap-10 sm:p-10 lg:grid-cols-[1.2fr_0.8fr] lg:gap-12">
-          <div class="space-y-6">
-            <p class="text-sm uppercase tracking-[0.3em] text-[#b9824b]">Enerji güvenliği</p>
-            <h2 class="text-3xl font-semibold tracking-tight text-white sm:text-4xl">Enerji projelerinizi ileriye taşıyan bağımsız mühendislik ortağı</h2>
-            <p class="text-base leading-relaxed text-white/80">
-              Enerji Grup Teknik Mühendislik, makine mühendisleri ve NDT uzmanlarından oluşan disiplinler arası ekibiyle enerji ve proses tesislerindeki riskleri görünür kılar, verimliliği artıran güvenlik çözümlerini sahaya taşır. Kurucu kadromuzun 15 yılı aşan deneyimi her çalışmada mevzuata uyum ve sürdürülebilirliği birlikte ele almamızı sağlar.
-            </p>
-            <div class="flex flex-col gap-4 sm:flex-row">
-              <a class="inline-flex items-center justify-center rounded-full border border-transparent bg-gradient-to-r from-[#b9824b] via-[#d79d60] to-[#3f85c6] px-8 py-3 text-sm font-semibold text-[#081a2c] shadow-[0_10px_35px_rgba(12,30,43,0.45)] transition hover:scale-105" href="hizmetler.html">
-                Hizmetlerimizi İnceleyin
-              </a>
-              <span class="inline-flex items-center justify-center rounded-full border border-white/20 bg-white/5 px-8 py-3 text-sm font-semibold text-white/75">
-                15+ yıllık saha deneyimi
-              </span>
-            </div>
-          </div>
-          <div class="space-y-6">
-            <div class="rounded-[28px] border border-dashed border-white/20 bg-white/10 p-6 text-center text-sm text-white/70 sm:p-8">
-              <p class="font-medium text-white">Logo için ayrılan alan</p>
-              <p class="mt-2 leading-relaxed text-white/70">
-                Firmanızın güncel logosunu bu alana ekleyebilirsiniz. Görsel oranı 1:1 olacak şekilde (ör. 600×600px PNG) eklenmesi önerilir.
+        <section class="overflow-hidden rounded-[36px] border border-white/10 bg-gradient-to-br from-[#0f2a45]/95 via-[#163d5f]/90 to-[#0a233d]/95 shadow-[0_25px_60px_rgba(5,12,16,0.55)]">
+          <div class="grid items-center gap-8 p-6 sm:gap-10 sm:p-10 lg:grid-cols-[1.05fr_0.95fr]">
+            <div class="space-y-6">
+              <p class="text-xs uppercase tracking-[0.35em] text-[#b9824b]">Sürekliliğinizi planlayın</p>
+              <h2 class="text-3xl font-semibold tracking-tight text-white sm:text-4xl">Periyodik kontrol yaklaşımımız</h2>
+              <p class="text-base leading-relaxed text-white/80">
+                TS ISO 5057 standardı ekipman muayene periyotlarını belirler; biz de bu rehbere ek olarak işletmenin kullanım sıklığı ve çalışma koşullarına göre özel kontrol planları hazırlıyoruz.
               </p>
             </div>
-            <div class="space-y-3 rounded-[28px] border border-white/10 bg-[#14324d]/70 p-6">
-              <p class="text-sm font-semibold uppercase tracking-[0.2em] text-[#b9824b]">Kuruluş</p>
-              <p class="text-sm leading-relaxed text-white/80">
-                2023'te Mersin'de kurulan firmamız, endüstriyel tesislerin bakım, kontrol ve belgelendirme ihtiyacına çözüm sunmak için tecrübeli mühendisleri ortak bir çatı altında buluşturdu.
-              </p>
+            <div class="relative h-full min-h-[220px] overflow-hidden rounded-[28px] border border-white/10 sm:min-h-[320px]">
+              <img class="h-full w-full object-cover opacity-80" src="https://images.unsplash.com/photo-1518770660439-4636190af475?auto=format&amp;fit=crop&amp;w=1200&amp;q=80" alt="Periyodik kontrol ekipmanı" loading="lazy" />
+              <div class="absolute inset-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent"></div>
             </div>
           </div>
         </section>
 
-        <section class="fade-in space-y-10" aria-labelledby="kesfet-baslik">
-          <div class="space-y-4 text-center">
-            <p class="text-xs uppercase tracking-[0.35em] text-[#b9824b]">Ana menü</p>
-            <h2 id="kesfet-baslik" class="text-3xl font-semibold tracking-tight text-white">Enerji Grup Teknik'i keşfedin</h2>
-            <p class="mx-auto max-w-3xl text-sm leading-relaxed text-white/75">
-              Kurumsal anlatımızı, uzmanlık öne çıkanlarını ve teknik içerikleri tematik sayfalarda topladık. Fotoğraflı kartlara dokunarak sizi ilgilendiren konuya birkaç saniyede ulaşabilirsiniz.
+        <section class="fade-in space-y-10">
+          <div class="grid gap-6 lg:grid-cols-3">
+            <article class="rounded-[24px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] p-6 text-sm leading-relaxed text-white/80">
+              <h3 class="text-base font-semibold text-white">TS ISO 5057 – Muayene aralıkları</h3>
+              <p class="mt-3">
+                TS ISO 5057 standardının 4. maddesi periyodik muayene aralıklarını, 5.2 maddesi ise yüzey çatlaklarına ilişkin kriterleri ortaya koyar. Kullanım sıklığı, ortam koşulları ve üretici tavsiyeleri değerlendirilerek ekipmanlar için en fazla bir yıllık periyotlarla kontroller planlanır; kritik bulgular olduğunda aralıklar kısaltılır.
+              </p>
+            </article>
+            <article class="rounded-[24px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] p-6 text-sm leading-relaxed text-white/80">
+              <h3 class="text-base font-semibold text-white">İstif makineleri ve kaldırma ekipmanları</h3>
+              <p class="mt-3">
+                Forklift, transpalet ve personel kaldırma platformları için TS ISO 5057, TS EN ISO 3691-5 ve ilgili FEM standartları yılda en az bir kez tahribatsız muayene yapılmasını önerir. Çatlak, deformasyon ve aşınmalar erkenden tespit edilerek ekipman güvenliği korunur.
+              </p>
+            </article>
+            <article class="rounded-[24px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] p-6 text-sm leading-relaxed text-white/80">
+              <h3 class="text-base font-semibold text-white">Beton pompaları ve mevzuat</h3>
+              <p class="mt-3">
+                EN 12001 standardı beton pompaları ve dağıtım kollarının periyodik kontrolünü zorunlu kılar. TS EN 12001 olarak yayımlanan bu standart ve 10.04.2013 tarihli resmi duyurular, kontrollerin yetkili uzmanlarca yapılmasını şart koşar. Bakanlık yayınları da beton pompalarının her yıl yetkili uzmanlar tarafından kontrol edilmesini vurgular.
+              </p>
+            </article>
+          </div>
+
+          <article class="rounded-[28px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] p-6 leading-relaxed text-white/80 sm:p-8">
+            <h3 class="text-xl font-semibold text-white">Periyodik kontrol kapsamımız</h3>
+            <ul class="mt-4 space-y-3 text-sm text-white/75">
+              <li>• Basınçlı kaplar, hava tankları ve hidrofor sistemlerinde sızdırmazlık, dayanım ve emniyet aksesuarı kontrolleri</li>
+              <li>• Kaldırma iletme ekipmanlarında (vinç, caraskal, platform, forklift) yapısal bütünlük, güvenlik ekipmanları ve NDT kontrolleri</li>
+              <li>• Pompa performans testlerinde debi, basınç, enerji tüketimi ve verim ölçümleri</li>
+              <li>• Elektrik tesisatı, parafudor ve topraklama ölçümlerinde ulusal standartlara uygunluk değerlendirmesi</li>
+            </ul>
+          </article>
+
+          <div class="space-y-6 rounded-[28px] border border-[#3f85c6]/30 bg-gradient-to-br from-[#17283a]/95 via-[#1e3044]/90 to-[#111b27]/95 p-6 text-white/80 sm:p-8">
+            <p class="text-xs uppercase tracking-[0.32em] text-[#d79d60]">Tesisatların periyodik kontrolleri</p>
+            <h3 class="text-2xl font-semibold tracking-tight text-white">Yasal yükümlülükler ve testler</h3>
+            <p>
+              İş Ekipmanlarının Kullanımında Sağlık ve Güvenlik Şartları Yönetmeliği ile 6331 sayılı İş Sağlığı ve Güvenliği Kanunu; yangın, klima-havalandırma, elektrik, topraklama ve paratoner tesisatlarının en az yılda bir kez kontrol edilmesini zorunlu kılar.
             </p>
+            <p>
+              TS EN 12845 standardının yıllık rutin kontrolleri, yangın pompalarının farklı yük aralıklarında test edilmesini ve sonuçların yazılı olarak arşivlenmesini ister. Enerji Grup Teknik Mühendislik olarak performans testlerini dört çalışma periyodunda planlayarak raporluyoruz.
+            </p>
+            <ul class="space-y-3 text-sm text-white/75">
+              <li>• Yangın tesisatı periyodik kontrolleri ve yangın pompaları performans testleri</li>
+              <li>• Boru, elektrik ve topraklama tesisatlarının uygunluk değerlendirmeleri</li>
+              <li>• Paratoner tesisatının ölçümü, raporlanması ve jeneratör periyodik kontrolleri</li>
+              <li>• Klima ve havalandırma sistemlerinin işletme şartlarına göre performans takibi</li>
+            </ul>
+            <div class="overflow-x-auto rounded-[24px] border border-white/10 bg-[#101b28]/70 p-4 sm:p-6">
+              <table class="w-full text-left text-sm text-white/75">
+                <thead class="text-xs uppercase tracking-[0.24em] text-[#d79d60]">
+                  <tr>
+                    <th class="pb-4 pr-6 font-semibold text-white">Ekipman</th>
+                    <th class="pb-4 pr-6 font-semibold text-white">Azami kontrol periyodu</th>
+                    <th class="pb-4 font-semibold text-white">Kontrol kriterleri</th>
+                  </tr>
+                </thead>
+                <tbody class="divide-y divide-white/10">
+                  <tr>
+                    <td class="py-4 pr-6 align-top">Elektrik, topraklama ve paratoner tesisatları</td>
+                    <td class="py-4 pr-6 align-top">İlgili standartlarda tanımlanan süreler (çoğunlukla yılda 1)</td>
+                    <td class="py-4 align-top">
+                      TS EN 60079, TS HD 60364 ve Elektrik Tesisleri Yönetmeliği hükümlerine göre izolasyon, süreklilik ve ölçüm değerlerinin raporlanması
+                      gerekmektedir.
+                    </td>
+                  </tr>
+                  <tr>
+                    <td class="py-4 pr-6 align-top">Akümülatörler ve transformatörler</td>
+                    <td class="py-4 pr-6 align-top">1 yıl</td>
+                    <td class="py-4 align-top">Dielektrik dayanım deneyleri ile yağ analizlerinin sonuçları standartlara göre değerlendirilir.</td>
+                  </tr>
+                  <tr>
+                    <td class="py-4 pr-6 align-top">Yangın pompaları ve boru tesisatı</td>
+                    <td class="py-4 pr-6 align-top">TS EN 12845'e göre yıllık rutin kontrol</td>
+                    <td class="py-4 align-top">Debi, basınç ve otomasyon fonksiyonlarının dört çalışma periyodunda doğrulanması ve kayıt altına alınması gerekir.</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
           </div>
-          <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
-            <a class="group relative overflow-hidden rounded-[28px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] transition hover:-translate-y-1 hover:border-[#b9824b]/60" href="hakkimizda.html">
-              <img class="h-40 w-full object-cover opacity-80 transition duration-500 group-hover:scale-105 sm:h-48" src="https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&amp;fit=crop&amp;w=900&amp;q=80" alt="Kurumsal binayı temsil eden gece ışıkları" loading="lazy" />
-              <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent"></div>
-              <div class="relative space-y-3 p-6">
-                <p class="text-xs uppercase tracking-[0.3em] text-[#b9824b]">Kurumsal</p>
-                <h3 class="text-xl font-semibold text-white">Hakkımızda</h3>
-                <p class="text-sm text-white/80">Kurumsal yapılanmamızı ve bağımsız çalışma kültürümüzü inceleyin.</p>
-                <span class="inline-flex items-center gap-2 text-sm font-semibold text-[#d79d60]">Sayfayı aç <svg class="size-4" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9 6L15 12L9 18" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" /></svg></span>
-              </div>
-            </a>
-            <a class="group relative overflow-hidden rounded-[28px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] transition hover:-translate-y-1 hover:border-[#b9824b]/60" href="misyon-vizyon.html">
-              <img class="h-40 w-full object-cover opacity-80 transition duration-500 group-hover:scale-105 sm:h-48" src="https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&amp;fit=crop&amp;w=900&amp;q=80" alt="Soyut ışıklarla çizilmiş vizyon konsepti" loading="lazy" />
-              <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent"></div>
-              <div class="relative space-y-3 p-6">
-                <p class="text-xs uppercase tracking-[0.3em] text-[#b9824b]">Strateji</p>
-                <h3 class="text-xl font-semibold text-white">Misyon &amp; Vizyon</h3>
-                <p class="text-sm text-white/80">Yol haritamızı şekillendiren hedefleri ve değer zincirimizi keşfedin.</p>
-                <span class="inline-flex items-center gap-2 text-sm font-semibold text-[#d79d60]">Sayfayı aç <svg class="size-4" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9 6L15 12L9 18" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" /></svg></span>
-              </div>
-            </a>
-            <a class="group relative overflow-hidden rounded-[28px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] transition hover:-translate-y-1 hover:border-[#b9824b]/60" href="uzman-kadro.html">
-              <img class="h-40 w-full object-cover opacity-80 transition duration-500 group-hover:scale-105 sm:h-48" src="https://images.unsplash.com/photo-1581091870627-3fdc0086580d?auto=format&amp;fit=crop&amp;w=900&amp;q=80" alt="Teknik ekip çalışmasını temsil eden görsel" loading="lazy" />
-              <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent"></div>
-              <div class="relative space-y-3 p-6">
-                <p class="text-xs uppercase tracking-[0.3em] text-[#b9824b]">Ekip</p>
-                <h3 class="text-xl font-semibold text-white">Uzman Kadro</h3>
-                <p class="text-sm text-white/80">Saha deneyimi yüksek ekibimizin yetkinliklerini yakından görün.</p>
-                <span class="inline-flex items-center gap-2 text-sm font-semibold text-[#d79d60]">Sayfayı aç <svg class="size-4" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9 6L15 12L9 18" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" /></svg></span>
-              </div>
-            </a>
-            <a class="group relative overflow-hidden rounded-[28px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] transition hover:-translate-y-1 hover:border-[#b9824b]/60" href="hizmetler.html">
-              <img class="h-40 w-full object-cover opacity-80 transition duration-500 group-hover:scale-105 sm:h-48" src="https://images.unsplash.com/photo-1503387762-592deb58ef4e?auto=format&amp;fit=crop&amp;w=900&amp;q=80" alt="Endüstriyel tesislerde mühendislik hizmetlerini simgeleyen görsel" loading="lazy" />
-              <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent"></div>
-              <div class="relative space-y-3 p-6">
-                <p class="text-xs uppercase tracking-[0.3em] text-[#b9824b]">Çözümler</p>
-                <h3 class="text-xl font-semibold text-white">Hizmetlerimiz</h3>
-                <p class="text-sm text-white/80">Kontrol, danışmanlık ve tasarım başlıklarının tamamını keşfedin.</p>
-                <span class="inline-flex items-center gap-2 text-sm font-semibold text-[#d79d60]">Sayfayı aç <svg class="size-4" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9 6L15 12L9 18" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" /></svg></span>
-              </div>
-            </a>
-            <a class="group relative overflow-hidden rounded-[28px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] transition hover:-translate-y-1 hover:border-[#b9824b]/60" href="ndt.html">
-              <img class="h-40 w-full object-cover opacity-80 transition duration-500 group-hover:scale-105 sm:h-48" src="https://images.unsplash.com/photo-1517433456452-f9633a875f6f?auto=format&amp;fit=crop&amp;w=900&amp;q=80" alt="Tahribatsız muayene ekipmanı" loading="lazy" />
-              <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent"></div>
-              <div class="relative space-y-3 p-6">
-                <p class="text-xs uppercase tracking-[0.3em] text-[#b9824b]">Denetim</p>
-                <h3 class="text-xl font-semibold text-white">Tahribatsız Muayene</h3>
-                <p class="text-sm text-white/80">Uluslararası standartlara dayalı NDT yöntemlerimizi inceleyin.</p>
-                <span class="inline-flex items-center gap-2 text-sm font-semibold text-[#d79d60]">Sayfayı aç <svg class="size-4" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9 6L15 12L9 18" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" /></svg></span>
-              </div>
-            </a>
-            <a class="group relative overflow-hidden rounded-[28px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] transition hover:-translate-y-1 hover:border-[#b9824b]/60" href="periyodik-kontroller.html">
-              <img class="h-40 w-full object-cover opacity-80 transition duration-500 group-hover:scale-105 sm:h-48" src="https://images.unsplash.com/photo-1518770660439-4636190af475?auto=format&amp;fit=crop&amp;w=900&amp;q=80" alt="Periyodik kontrol ve bakım süreçlerini temsil eden görsel" loading="lazy" />
-              <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent"></div>
-              <div class="relative space-y-3 p-6">
-                <p class="text-xs uppercase tracking-[0.3em] text-[#b9824b]">Süreklilik</p>
-                <h3 class="text-xl font-semibold text-white">Periyodik Kontroller</h3>
-                <p class="text-sm text-white/80">Zorunlu periyodik kontrol başlıklarının tamamına göz atın.</p>
-                <span class="inline-flex items-center gap-2 text-sm font-semibold text-[#d79d60]">Sayfayı aç <svg class="size-4" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9 6L15 12L9 18" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" /></svg></span>
-              </div>
-            </a>
-          </div>
+
+          <article class="rounded-[28px] border border-[#b9824b]/30 bg-gradient-to-br from-[#1a2a3b]/95 via-[#1f3246]/90 to-[#111b27]/95 p-6 leading-relaxed text-white/80 sm:p-8">
+            <p class="text-xs uppercase tracking-[0.32em] text-[#d79d60]">Basınçlı kaplar</p>
+            <h3 class="mt-3 text-2xl font-semibold tracking-tight text-white">Basınçlı ekipmanlarda güvenlik başlıkları</h3>
+            <p class="mt-4">
+              Basınçlı kapların ve güvenlik elemanlarının sağlamlığı; sızıntı, aşınma, korozyon, deformasyon, çatlak ve bağlantı hatalarının düzenli kontrol edilmesine bağlıdır. Gerekli denetimler yapılmadığında ekipman hasarları, iş kazaları ve üretim kayıpları kaçınılmaz hale gelir.
+            </p>
+            <p class="mt-4">
+              İş Ekipmanlarının Kullanımında Sağlık ve Güvenlik Şartları Yönetmeliği ile 6331 sayılı kanun, 0.5 bar üzerindeki basınçlı ekipmanlar için periyodik kontrol kriterlerini tanımlar. Enerji Grup Teknik Mühendislik olarak kalifiye mühendislerimizle hidrostatik basınç testleri, manyetik parçacık, ultrasonik ve sıvı penetrant muayeneleri ile görsel kontrolleri gerçekleştiriyoruz.
+            </p>
+            <p class="mt-4">
+              Hava tankları, buhar kazanları, kompresörler ve otoklavlar gibi ekipmanların test ve kontrollerini kalibreli ölçüm cihazlarıyla yapıyor, sonuçları raporlayarak işletmelerin yasal sorumluluklarını yerine getirmesine destek oluyoruz.
+            </p>
+          </article>
         </section>
       </main>
 

--- a/uzman-kadro.html
+++ b/uzman-kadro.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Enerji Grup Teknik Mühendislik</title>
+    <title>Uzman Kadro | Enerji Grup Teknik Mühendislik</title>
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       rel="stylesheet"
@@ -125,10 +125,10 @@
               </svg>
             </button>
             <nav class="hidden items-center gap-8 text-sm font-medium text-white/75 lg:flex">
-              <a class="text-white transition" href="index.html">Anasayfa</a>
+              <a class="transition hover:text-white" href="index.html">Anasayfa</a>
               <a class="transition hover:text-white" href="hakkimizda.html">Hakkımızda</a>
               <a class="transition hover:text-white" href="misyon-vizyon.html">Misyon &amp; Vizyon</a>
-              <a class="transition hover:text-white" href="uzman-kadro.html">Uzman Kadro</a>
+              <a class="text-white transition" href="uzman-kadro.html">Uzman Kadro</a>
               <a class="transition hover:text-white" href="hizmetler.html">Hizmetler</a>
               <a class="transition hover:text-white" href="ndt.html">Tahribatsız Muayene</a>
               <a class="transition hover:text-white" href="periyodik-kontroller.html">Periyodik Kontroller</a>
@@ -140,7 +140,7 @@
             <a class="rounded-xl px-4 py-3 transition hover:bg-white/10" href="index.html">Anasayfa</a>
             <a class="rounded-xl px-4 py-3 transition hover:bg-white/10" href="hakkimizda.html">Hakkımızda</a>
             <a class="rounded-xl px-4 py-3 transition hover:bg-white/10" href="misyon-vizyon.html">Misyon &amp; Vizyon</a>
-            <a class="rounded-xl px-4 py-3 transition hover:bg-white/10" href="uzman-kadro.html">Uzman Kadro</a>
+            <a class="rounded-xl px-4 py-3 transition hover:bg-white/10 text-white" href="uzman-kadro.html">Uzman Kadro</a>
             <a class="rounded-xl px-4 py-3 transition hover:bg-white/10" href="hizmetler.html">Hizmetler</a>
             <a class="rounded-xl px-4 py-3 transition hover:bg-white/10" href="ndt.html">Tahribatsız Muayene</a>
             <a class="rounded-xl px-4 py-3 transition hover:bg-white/10" href="periyodik-kontroller.html">Periyodik Kontroller</a>
@@ -149,107 +149,26 @@
       </header>
 
       <main class="mx-auto flex w-full max-w-[1200px] flex-col gap-12 px-5 py-12 sm:gap-16 sm:px-10 sm:py-16 lg:px-20">
-        <section class="grid items-center gap-8 rounded-[32px] border border-white/10 bg-gradient-to-br from-[#0f2a45]/95 via-[#163d5f]/88 to-[#0a233d]/95 p-6 shadow-[0_25px_60px_rgba(7,20,39,0.55)] sm:gap-10 sm:p-10 lg:grid-cols-[1.2fr_0.8fr] lg:gap-12">
-          <div class="space-y-6">
-            <p class="text-sm uppercase tracking-[0.3em] text-[#b9824b]">Enerji güvenliği</p>
-            <h2 class="text-3xl font-semibold tracking-tight text-white sm:text-4xl">Enerji projelerinizi ileriye taşıyan bağımsız mühendislik ortağı</h2>
-            <p class="text-base leading-relaxed text-white/80">
-              Enerji Grup Teknik Mühendislik, makine mühendisleri ve NDT uzmanlarından oluşan disiplinler arası ekibiyle enerji ve proses tesislerindeki riskleri görünür kılar, verimliliği artıran güvenlik çözümlerini sahaya taşır. Kurucu kadromuzun 15 yılı aşan deneyimi her çalışmada mevzuata uyum ve sürdürülebilirliği birlikte ele almamızı sağlar.
-            </p>
-            <div class="flex flex-col gap-4 sm:flex-row">
-              <a class="inline-flex items-center justify-center rounded-full border border-transparent bg-gradient-to-r from-[#b9824b] via-[#d79d60] to-[#3f85c6] px-8 py-3 text-sm font-semibold text-[#081a2c] shadow-[0_10px_35px_rgba(12,30,43,0.45)] transition hover:scale-105" href="hizmetler.html">
-                Hizmetlerimizi İnceleyin
-              </a>
-              <span class="inline-flex items-center justify-center rounded-full border border-white/20 bg-white/5 px-8 py-3 text-sm font-semibold text-white/75">
-                15+ yıllık saha deneyimi
-              </span>
-            </div>
-          </div>
-          <div class="space-y-6">
-            <div class="rounded-[28px] border border-dashed border-white/20 bg-white/10 p-6 text-center text-sm text-white/70 sm:p-8">
-              <p class="font-medium text-white">Logo için ayrılan alan</p>
-              <p class="mt-2 leading-relaxed text-white/70">
-                Firmanızın güncel logosunu bu alana ekleyebilirsiniz. Görsel oranı 1:1 olacak şekilde (ör. 600×600px PNG) eklenmesi önerilir.
+        <section class="overflow-hidden rounded-[36px] border border-white/10 bg-gradient-to-br from-[#0f2a45]/95 via-[#163d5f]/90 to-[#0a233d]/95 shadow-[0_25px_60px_rgba(5,12,16,0.55)]">
+          <div class="grid gap-8 p-6 sm:gap-10 sm:p-10 lg:grid-cols-[1.05fr_0.95fr]">
+            <div class="space-y-6">
+              <p class="text-xs uppercase tracking-[0.35em] text-[#b9824b]">Uzman kadro</p>
+              <h2 class="text-3xl font-semibold tracking-tight text-white sm:text-4xl">Belgelendirilmiş mühendislik ekibimiz</h2>
+              <p class="text-base leading-relaxed text-white/80">
+                Sanayi güvenliğini odağa alan, kendini sürekli güncelleyen uzman kadromuzla mevzuata uygun tahribatsız muayene ve periyodik kontrol hizmetlerini bütüncül bir bakış açısıyla yürütüyoruz.
               </p>
-            </div>
-            <div class="space-y-3 rounded-[28px] border border-white/10 bg-[#14324d]/70 p-6">
-              <p class="text-sm font-semibold uppercase tracking-[0.2em] text-[#b9824b]">Kuruluş</p>
-              <p class="text-sm leading-relaxed text-white/80">
-                2023'te Mersin'de kurulan firmamız, endüstriyel tesislerin bakım, kontrol ve belgelendirme ihtiyacına çözüm sunmak için tecrübeli mühendisleri ortak bir çatı altında buluşturdu.
+              <p class="text-base leading-relaxed text-white/80">
+                Zorunlu periyodik kontrolleri gerçekleştiren personelin deneyimi ve belge yeterliliği hizmetin kalitesini belirler. Bu yüzden ekibimizin tamamı TS EN ISO 9712 başta olmak üzere ilgili standartlara göre eğitimlerini tamamlamış, belgeleri eksiksiz profesyonellerden oluşur.
               </p>
+              <p class="text-base leading-relaxed text-white/80">
+                Makine ve elektrik mühendislerinden NDT uzmanlarına, iş güvenliği ve yangın eğitimi profesyonellerine kadar çok disiplinli bir kadroyla çalışıyoruz. Proje planlamasından saha uygulamasına kadar Türkiye genelindeki sanayi kuruluşlarına değer katmayı hedefliyoruz.
+              </p>
+              <p class="text-sm font-semibold text-[#d79d60]">Zafer Korkut Yılmaz — Makina Mühendisi / NDT Uzmanı</p>
             </div>
-          </div>
-        </section>
-
-        <section class="fade-in space-y-10" aria-labelledby="kesfet-baslik">
-          <div class="space-y-4 text-center">
-            <p class="text-xs uppercase tracking-[0.35em] text-[#b9824b]">Ana menü</p>
-            <h2 id="kesfet-baslik" class="text-3xl font-semibold tracking-tight text-white">Enerji Grup Teknik'i keşfedin</h2>
-            <p class="mx-auto max-w-3xl text-sm leading-relaxed text-white/75">
-              Kurumsal anlatımızı, uzmanlık öne çıkanlarını ve teknik içerikleri tematik sayfalarda topladık. Fotoğraflı kartlara dokunarak sizi ilgilendiren konuya birkaç saniyede ulaşabilirsiniz.
-            </p>
-          </div>
-          <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
-            <a class="group relative overflow-hidden rounded-[28px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] transition hover:-translate-y-1 hover:border-[#b9824b]/60" href="hakkimizda.html">
-              <img class="h-40 w-full object-cover opacity-80 transition duration-500 group-hover:scale-105 sm:h-48" src="https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&amp;fit=crop&amp;w=900&amp;q=80" alt="Kurumsal binayı temsil eden gece ışıkları" loading="lazy" />
-              <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent"></div>
-              <div class="relative space-y-3 p-6">
-                <p class="text-xs uppercase tracking-[0.3em] text-[#b9824b]">Kurumsal</p>
-                <h3 class="text-xl font-semibold text-white">Hakkımızda</h3>
-                <p class="text-sm text-white/80">Kurumsal yapılanmamızı ve bağımsız çalışma kültürümüzü inceleyin.</p>
-                <span class="inline-flex items-center gap-2 text-sm font-semibold text-[#d79d60]">Sayfayı aç <svg class="size-4" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9 6L15 12L9 18" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" /></svg></span>
-              </div>
-            </a>
-            <a class="group relative overflow-hidden rounded-[28px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] transition hover:-translate-y-1 hover:border-[#b9824b]/60" href="misyon-vizyon.html">
-              <img class="h-40 w-full object-cover opacity-80 transition duration-500 group-hover:scale-105 sm:h-48" src="https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&amp;fit=crop&amp;w=900&amp;q=80" alt="Soyut ışıklarla çizilmiş vizyon konsepti" loading="lazy" />
-              <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent"></div>
-              <div class="relative space-y-3 p-6">
-                <p class="text-xs uppercase tracking-[0.3em] text-[#b9824b]">Strateji</p>
-                <h3 class="text-xl font-semibold text-white">Misyon &amp; Vizyon</h3>
-                <p class="text-sm text-white/80">Yol haritamızı şekillendiren hedefleri ve değer zincirimizi keşfedin.</p>
-                <span class="inline-flex items-center gap-2 text-sm font-semibold text-[#d79d60]">Sayfayı aç <svg class="size-4" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9 6L15 12L9 18" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" /></svg></span>
-              </div>
-            </a>
-            <a class="group relative overflow-hidden rounded-[28px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] transition hover:-translate-y-1 hover:border-[#b9824b]/60" href="uzman-kadro.html">
-              <img class="h-40 w-full object-cover opacity-80 transition duration-500 group-hover:scale-105 sm:h-48" src="https://images.unsplash.com/photo-1581091870627-3fdc0086580d?auto=format&amp;fit=crop&amp;w=900&amp;q=80" alt="Teknik ekip çalışmasını temsil eden görsel" loading="lazy" />
-              <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent"></div>
-              <div class="relative space-y-3 p-6">
-                <p class="text-xs uppercase tracking-[0.3em] text-[#b9824b]">Ekip</p>
-                <h3 class="text-xl font-semibold text-white">Uzman Kadro</h3>
-                <p class="text-sm text-white/80">Saha deneyimi yüksek ekibimizin yetkinliklerini yakından görün.</p>
-                <span class="inline-flex items-center gap-2 text-sm font-semibold text-[#d79d60]">Sayfayı aç <svg class="size-4" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9 6L15 12L9 18" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" /></svg></span>
-              </div>
-            </a>
-            <a class="group relative overflow-hidden rounded-[28px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] transition hover:-translate-y-1 hover:border-[#b9824b]/60" href="hizmetler.html">
-              <img class="h-40 w-full object-cover opacity-80 transition duration-500 group-hover:scale-105 sm:h-48" src="https://images.unsplash.com/photo-1503387762-592deb58ef4e?auto=format&amp;fit=crop&amp;w=900&amp;q=80" alt="Endüstriyel tesislerde mühendislik hizmetlerini simgeleyen görsel" loading="lazy" />
-              <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent"></div>
-              <div class="relative space-y-3 p-6">
-                <p class="text-xs uppercase tracking-[0.3em] text-[#b9824b]">Çözümler</p>
-                <h3 class="text-xl font-semibold text-white">Hizmetlerimiz</h3>
-                <p class="text-sm text-white/80">Kontrol, danışmanlık ve tasarım başlıklarının tamamını keşfedin.</p>
-                <span class="inline-flex items-center gap-2 text-sm font-semibold text-[#d79d60]">Sayfayı aç <svg class="size-4" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9 6L15 12L9 18" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" /></svg></span>
-              </div>
-            </a>
-            <a class="group relative overflow-hidden rounded-[28px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] transition hover:-translate-y-1 hover:border-[#b9824b]/60" href="ndt.html">
-              <img class="h-40 w-full object-cover opacity-80 transition duration-500 group-hover:scale-105 sm:h-48" src="https://images.unsplash.com/photo-1517433456452-f9633a875f6f?auto=format&amp;fit=crop&amp;w=900&amp;q=80" alt="Tahribatsız muayene ekipmanı" loading="lazy" />
-              <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent"></div>
-              <div class="relative space-y-3 p-6">
-                <p class="text-xs uppercase tracking-[0.3em] text-[#b9824b]">Denetim</p>
-                <h3 class="text-xl font-semibold text-white">Tahribatsız Muayene</h3>
-                <p class="text-sm text-white/80">Uluslararası standartlara dayalı NDT yöntemlerimizi inceleyin.</p>
-                <span class="inline-flex items-center gap-2 text-sm font-semibold text-[#d79d60]">Sayfayı aç <svg class="size-4" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9 6L15 12L9 18" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" /></svg></span>
-              </div>
-            </a>
-            <a class="group relative overflow-hidden rounded-[28px] border border-white/10 bg-gradient-to-br from-[#0d243d] via-[#163a58] to-[#0a1d33] transition hover:-translate-y-1 hover:border-[#b9824b]/60" href="periyodik-kontroller.html">
-              <img class="h-40 w-full object-cover opacity-80 transition duration-500 group-hover:scale-105 sm:h-48" src="https://images.unsplash.com/photo-1518770660439-4636190af475?auto=format&amp;fit=crop&amp;w=900&amp;q=80" alt="Periyodik kontrol ve bakım süreçlerini temsil eden görsel" loading="lazy" />
-              <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent"></div>
-              <div class="relative space-y-3 p-6">
-                <p class="text-xs uppercase tracking-[0.3em] text-[#b9824b]">Süreklilik</p>
-                <h3 class="text-xl font-semibold text-white">Periyodik Kontroller</h3>
-                <p class="text-sm text-white/80">Zorunlu periyodik kontrol başlıklarının tamamına göz atın.</p>
-                <span class="inline-flex items-center gap-2 text-sm font-semibold text-[#d79d60]">Sayfayı aç <svg class="size-4" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9 6L15 12L9 18" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" /></svg></span>
-              </div>
-            </a>
+            <div class="relative h-full min-h-[220px] overflow-hidden rounded-[28px] border border-white/10 sm:min-h-[320px]">
+              <img class="h-full w-full object-cover opacity-80" src="https://images.unsplash.com/photo-1581090700227-1e37b190418e?auto=format&amp;fit=crop&amp;w=1200&amp;q=80" alt="Teknik ekip toplantısı" loading="lazy" />
+              <div class="absolute inset-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent"></div>
+            </div>
           </div>
         </section>
       </main>
@@ -264,7 +183,7 @@
                 <span class="inline-flex w-fit items-center gap-2 rounded-full border border-white/15 bg-white/10 px-4 py-1.5 text-xs font-semibold uppercase tracking-[0.32em] text-[#c9d6df]">Enerji Grup Teknik</span>
                 <h2 class="text-3xl font-semibold tracking-tight sm:text-4xl">Geleceğin enerjisini birlikte inşa edelim</h2>
                 <p class="max-w-xl text-sm leading-relaxed text-white/75">
-                  Yetkin mühendis kadromuzla enerji altyapısındaki kritik riskleri analiz ediyor, işletmelerin güvenliğini güçlendiren çağdaş çözümler geliştiriyoruz.
+                  Yetkin mühendis kadromuzla enerji altyapısındaki riskleri analiz ediyor, işletmelerin güvenliğini güçlendiren çağdaş çözümler geliştiriyoruz.
                 </p>
               </div>
               <a class="inline-flex items-center justify-center gap-2 rounded-full border border-[#b9824b]/40 bg-gradient-to-r from-[#b9824b] via-[#d79d60] to-[#3f85c6] px-8 py-3 text-sm font-semibold text-[#081a2c] shadow-[0_15px_45px_rgba(10,25,36,0.55)] transition hover:scale-105" href="mailto:info@enerjigrupteknik.com">


### PR DESCRIPTION
## Summary
- align all brochure pages to a copper–blue–white palette with shared CSS variables, gradients, and footer accents
- rewrite the homepage hero, navigation cards, and copy blocks to describe Enerji Grup Teknik in original wording
- refresh service pages (NDT, kaynaklı imalat, periyodik kontroller) with rephrased explanations and consistent mobile palette accents

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e421c2bdac8325bd2ed48751ad63af